### PR TITLE
Improve RageLib performance

### DIFF
--- a/RageLib.GTA5/ResourceWrappers/PC/Meta/MetaReader.cs
+++ b/RageLib.GTA5/ResourceWrappers/PC/Meta/MetaReader.cs
@@ -205,12 +205,9 @@ namespace RageLib.GTA5.ResourceWrappers.PC.Meta
             return result;
         }
 
-        private byte[] ToBytes(ResourceSimpleArray<byte_r> data)
+        private byte[] ToBytes(SimpleArray<byte> data)
         {
-            var result = new byte[data.Count];
-            for (int i = 0; i < data.Count; i++)
-                result[i] = data[i].Value;
-            return result;
+            return data.ToArray();
         }
 
         public static StructureInfo GetInfo(MetaFile meta, int structureKey)

--- a/RageLib.GTA5/ResourceWrappers/PC/Meta/MetaWriter.cs
+++ b/RageLib.GTA5/ResourceWrappers/PC/Meta/MetaWriter.cs
@@ -91,17 +91,15 @@ namespace RageLib.GTA5.ResourceWrappers.PC.Meta
             return meta;
         }
 
-        private ResourceSimpleArray<byte_r> StreamToResourceBytes(Stream stream)
+        private SimpleArray<byte> StreamToResourceBytes(Stream stream)
         {
-            var resourceBytes = new ResourceSimpleArray<byte_r>();
+            var resourceBytes = new SimpleArray<byte>();
             var buffer = new byte[stream.Length];
             stream.Position = 0;
             stream.Read(buffer, 0, (int)stream.Length);
             foreach (var b in buffer)
             {
-                var rb = new byte_r();
-                rb.Value = b;
-                resourceBytes.Add(rb);
+                resourceBytes.Add(b);
             }
             return resourceBytes;
         }

--- a/RageLib.GTA5/ResourceWrappers/PC/Meta/MetaWriter.cs
+++ b/RageLib.GTA5/ResourceWrappers/PC/Meta/MetaWriter.cs
@@ -93,15 +93,10 @@ namespace RageLib.GTA5.ResourceWrappers.PC.Meta
 
         private SimpleArray<byte> StreamToResourceBytes(Stream stream)
         {
-            var resourceBytes = new SimpleArray<byte>();
             var buffer = new byte[stream.Length];
             stream.Position = 0;
             stream.Read(buffer, 0, (int)stream.Length);
-            foreach (var b in buffer)
-            {
-                resourceBytes.Add(b);
-            }
-            return resourceBytes;
+            return new SimpleArray<byte>(buffer);
         }
 
         private void MetaInitialize()

--- a/RageLib.GTA5/ResourceWrappers/PC/Textures/TextureDictionaryFile_GTA5_pc.cs
+++ b/RageLib.GTA5/ResourceWrappers/PC/Textures/TextureDictionaryFile_GTA5_pc.cs
@@ -47,7 +47,7 @@ namespace RageLib.GTA5.ResourceWrappers.PC.Textures
         public TextureDictionaryFileWrapper_GTA5_pc()
         {
             textureDictionary = new PgDictionary64<TextureDX11>();
-            textureDictionary.Hashes = new ResourceSimpleList64<uint_r>();
+            textureDictionary.Hashes = new SimpleList64<uint>();
             textureDictionary.Values = new ResourcePointerList64<TextureDX11>();
         }
 

--- a/RageLib.GTA5/ResourceWrappers/PC/Textures/TextureDictionaryWrapper_GTA5_pc.cs
+++ b/RageLib.GTA5/ResourceWrappers/PC/Textures/TextureDictionaryWrapper_GTA5_pc.cs
@@ -86,11 +86,11 @@ namespace RageLib.GTA5.ResourceWrappers.PC.Textures
                 theHashList.Sort();
 
                 var bak = textureDictionary.Values.Entries;
-                textureDictionary.Hashes.Entries = new ResourceSimpleArray<uint_r>();
+                textureDictionary.Hashes.Entries = new SimpleArray<uint>();
                 textureDictionary.Values.Entries = new ResourcePointerArray64<TextureDX11>();
                 foreach (uint x in theHashList)
                 {
-                    textureDictionary.Hashes.Entries.Add((uint_r)x);
+                    textureDictionary.Hashes.Entries.Add(x);
                     foreach (var g in bak)
                     {
                         uint tx = Jenkins.Hash((string)g.Name);
@@ -99,7 +99,7 @@ namespace RageLib.GTA5.ResourceWrappers.PC.Textures
                     }
                 }
 
-                //textureDictionary.Hashes = new ResourceSimpleArray<uint_r>();            
+                //textureDictionary.Hashes = new SimpleArray<uint>();            
                 //foreach (var texture in textureDictionary.Textures)
                 //{
                 //    uint hash = Jenkins.Hash((string)texture.Name);

--- a/RageLib.GTA5/ResourceWrappers/PC/Textures/TextureDictionaryWrapper_GTA5_pc.cs
+++ b/RageLib.GTA5/ResourceWrappers/PC/Textures/TextureDictionaryWrapper_GTA5_pc.cs
@@ -86,11 +86,10 @@ namespace RageLib.GTA5.ResourceWrappers.PC.Textures
                 theHashList.Sort();
 
                 var bak = textureDictionary.Values.Entries;
-                textureDictionary.Hashes.Entries = new SimpleArray<uint>();
+                textureDictionary.Hashes.Entries = new SimpleArray<uint>(theHashList.ToArray());
                 textureDictionary.Values.Entries = new ResourcePointerArray64<TextureDX11>();
                 foreach (uint x in theHashList)
                 {
-                    textureDictionary.Hashes.Entries.Add(x);
                     foreach (var g in bak)
                     {
                         uint tx = Jenkins.Hash((string)g.Name);

--- a/RageLib.GTA5/Resources/PC/Bounds/BVH.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BVH.cs
@@ -23,6 +23,7 @@
 using RageLib.Resources.Common;
 using System.Collections.Generic;
 using System;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Bounds
 {
@@ -36,11 +37,11 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public uint Unknown_14h; // 0x00000000
         public uint Unknown_18h; // 0x00000000
         public uint Unknown_1Ch; // 0x00000000
-        public RAGE_Vector4 BoundingBoxMin;
-        public RAGE_Vector4 BoundingBoxMax;
-        public RAGE_Vector4 BoundingBoxCenter;
-        public RAGE_Vector4 QuantumInverse;
-        public RAGE_Vector4 Quantum; // bounding box dimension / 2^16
+        public Vector4 BoundingBoxMin;
+        public Vector4 BoundingBoxMax;
+        public Vector4 BoundingBoxCenter;
+        public Vector4 QuantumInverse;
+        public Vector4 Quantum; // bounding box dimension / 2^16
         public ResourceSimpleList64<BVHTreeInfo> Trees;
 
         /// <summary>
@@ -54,11 +55,11 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.BoundingBoxMin = reader.ReadBlock<RAGE_Vector4>();
-            this.BoundingBoxMax = reader.ReadBlock<RAGE_Vector4>();
-            this.BoundingBoxCenter = reader.ReadBlock<RAGE_Vector4>();
-            this.QuantumInverse = reader.ReadBlock<RAGE_Vector4>();
-            this.Quantum = reader.ReadBlock<RAGE_Vector4>();
+            this.BoundingBoxMin = reader.ReadVector4();
+            this.BoundingBoxMax = reader.ReadVector4();
+            this.BoundingBoxCenter = reader.ReadVector4();
+            this.QuantumInverse = reader.ReadVector4();
+            this.Quantum = reader.ReadVector4();
             this.Trees = reader.ReadBlock<ResourceSimpleList64<BVHTreeInfo>>();
         }
 
@@ -72,11 +73,11 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             writer.Write(this.Unknown_14h);
             writer.Write(this.Unknown_18h);
             writer.Write(this.Unknown_1Ch);
-            writer.WriteBlock(this.BoundingBoxMin);
-            writer.WriteBlock(this.BoundingBoxMax);
-            writer.WriteBlock(this.BoundingBoxCenter);
-            writer.WriteBlock(this.QuantumInverse);
-            writer.WriteBlock(this.Quantum);
+            writer.Write(this.BoundingBoxMin);
+            writer.Write(this.BoundingBoxMax);
+            writer.Write(this.BoundingBoxCenter);
+            writer.Write(this.QuantumInverse);
+            writer.Write(this.Quantum);
             writer.WriteBlock(this.Trees);
         }
 
@@ -84,11 +85,6 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         {
             return new Tuple<long, IResourceBlock>[] {
                 new Tuple<long, IResourceBlock>(0x00, Nodes),
-                new Tuple<long, IResourceBlock>(0x20, BoundingBoxMin),
-                new Tuple<long, IResourceBlock>(0x30, BoundingBoxMax),
-                new Tuple<long, IResourceBlock>(0x40, BoundingBoxCenter),
-                new Tuple<long, IResourceBlock>(0x50, QuantumInverse),
-                new Tuple<long, IResourceBlock>(0x60, Quantum),
                 new Tuple<long, IResourceBlock>(0x70, Trees)
             };
         }

--- a/RageLib.GTA5/Resources/PC/Bounds/Bound.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/Bound.cs
@@ -21,6 +21,7 @@
 */
 
 using System;
+using System.Numerics;
 using RageLib.Resources.Common;
 
 namespace RageLib.Resources.GTA5.PC.Bounds
@@ -38,15 +39,15 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public float RadiusAroundCentroid;
         public uint Unknown_18h;
         public uint Unknown_1Ch;
-        public RAGE_Vector3 BoundingBoxMax;
+        public Vector3 BoundingBoxMax;
         public float Margin;
-        public RAGE_Vector3 BoundingBoxMin;
+        public Vector3 BoundingBoxMin;
         public uint RefCount;
-        public RAGE_Vector3 CentroidOffset;
+        public Vector3 CentroidOffset;
         public uint MaterialId0;
-        public RAGE_Vector3 CGOffset;
+        public Vector3 CGOffset;
         public uint MaterialId1;
-        public RAGE_Vector4 VolumeDistribution;
+        public Vector4 VolumeDistribution;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -62,15 +63,15 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             this.RadiusAroundCentroid = reader.ReadSingle();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.BoundingBoxMax = reader.ReadBlock<RAGE_Vector3>();
+            this.BoundingBoxMax = reader.ReadVector3();
             this.Margin = reader.ReadSingle();
-            this.BoundingBoxMin = reader.ReadBlock<RAGE_Vector3>();
+            this.BoundingBoxMin = reader.ReadVector3();
             this.RefCount = reader.ReadUInt32();
-            this.CentroidOffset = reader.ReadBlock<RAGE_Vector3>();
+            this.CentroidOffset = reader.ReadVector3();
             this.MaterialId0 = reader.ReadUInt32();
-            this.CGOffset = reader.ReadBlock<RAGE_Vector3>();
+            this.CGOffset = reader.ReadVector3();
             this.MaterialId1 = reader.ReadUInt32();
-            this.VolumeDistribution = reader.ReadBlock<RAGE_Vector4>();
+            this.VolumeDistribution = reader.ReadVector4();
         }
 
         /// <summary>
@@ -87,15 +88,15 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             writer.Write(this.RadiusAroundCentroid);
             writer.Write(this.Unknown_18h);
             writer.Write(this.Unknown_1Ch);
-            writer.WriteBlock(this.BoundingBoxMax);
+            writer.Write(this.BoundingBoxMax);
             writer.Write(this.Margin);
-            writer.WriteBlock(this.BoundingBoxMin);
+            writer.Write(this.BoundingBoxMin);
             writer.Write(this.RefCount);
-            writer.WriteBlock(this.CentroidOffset);
+            writer.Write(this.CentroidOffset);
             writer.Write(this.MaterialId0);
-            writer.WriteBlock(this.CGOffset);
+            writer.Write(this.CGOffset);
             writer.Write(this.MaterialId1);
-            writer.WriteBlock(this.VolumeDistribution);
+            writer.Write(this.VolumeDistribution);
         }
 
         public IResourceSystemBlock GetType(ResourceDataReader reader, params object[] parameters)

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundComposite.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundComposite.cs
@@ -48,8 +48,8 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public SimpleArray<Matrix4x4> ChildTransformations1;
         public SimpleArray<Matrix4x4> ChildTransformations2;
         public ResourceSimpleArray<RAGE_AABB> ChildBoundingBoxes;
-        public ResourceSimpleArray<ulong_r> ChildFlags1;
-        public ResourceSimpleArray<ulong_r> ChildFlags2;
+        public SimpleArray<ulong> ChildFlags1;
+        public SimpleArray<ulong> ChildFlags2;
         public BVH BVH;
 
         /// <summary>
@@ -88,11 +88,11 @@ namespace RageLib.Resources.GTA5.PC.Bounds
                 this.ChildBoundingBoxesPointer, // offset
                 this.ChildrenCount1
             );
-            this.ChildFlags1 = reader.ReadBlockAt<ResourceSimpleArray<ulong_r>>(
+            this.ChildFlags1 = reader.ReadBlockAt<SimpleArray<ulong>>(
                 this.ChildFlags1Pointer, // offset
                 this.ChildrenCount1
             );
-            this.ChildFlags2 = reader.ReadBlockAt<ResourceSimpleArray<ulong_r>>(
+            this.ChildFlags2 = reader.ReadBlockAt<SimpleArray<ulong>>(
                 this.ChildFlags2Pointer, // offset
                 this.ChildrenCount1
             );

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundComposite.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundComposite.cs
@@ -22,6 +22,7 @@
 
 using RageLib.Resources.Common;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Bounds
 {
@@ -44,8 +45,8 @@ namespace RageLib.Resources.GTA5.PC.Bounds
 
         // reference data
         public ResourcePointerArray64<Bound> Children;
-        public ResourceSimpleArray<RAGE_Matrix4x4> ChildTransformations1;
-        public ResourceSimpleArray<RAGE_Matrix4x4> ChildTransformations2;
+        public SimpleArray<Matrix4x4> ChildTransformations1;
+        public SimpleArray<Matrix4x4> ChildTransformations2;
         public ResourceSimpleArray<RAGE_AABB> ChildBoundingBoxes;
         public ResourceSimpleArray<ulong_r> ChildFlags1;
         public ResourceSimpleArray<ulong_r> ChildFlags2;
@@ -75,11 +76,11 @@ namespace RageLib.Resources.GTA5.PC.Bounds
                 this.ChildrenPointer, // offset
                 this.ChildrenCount1
             );
-            this.ChildTransformations1 = reader.ReadBlockAt<ResourceSimpleArray<RAGE_Matrix4x4>>(
+            this.ChildTransformations1 = reader.ReadBlockAt<SimpleArray<Matrix4x4>>(
                 this.ChildTransformations1Pointer, // offset
                 this.ChildrenCount1
             );
-            this.ChildTransformations2 = reader.ReadBlockAt<ResourceSimpleArray<RAGE_Matrix4x4>>(
+            this.ChildTransformations2 = reader.ReadBlockAt<SimpleArray<Matrix4x4>>(
                 this.ChildTransformations2Pointer, // offset
                 this.ChildrenCount1
             );

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundDictionary.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundDictionary.cs
@@ -34,7 +34,7 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public uint Unknown_14h; // 0x00000001
         public uint Unknown_18h; // 0x00000001
         public uint Unknown_1Ch; // 0x00000001
-        public ResourceSimpleList64<uint_r> BoundNameHashes;
+        public SimpleList64<uint> BoundNameHashes;
         public ResourcePointerList64<Bound> Bounds;
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.BoundNameHashes = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.BoundNameHashes = reader.ReadBlock<SimpleList64<uint>>();
             this.Bounds = reader.ReadBlock<ResourcePointerList64<Bound>>();
         }
 

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundGeometry.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundGeometry.cs
@@ -50,8 +50,8 @@ namespace RageLib.Resources.GTA5.PC.Bounds
 
         // reference data
         public ResourceSimpleArray<BoundMaterial> Materials;
-        public ResourceSimpleArray<uint_r> MaterialColours;
-        public ResourceSimpleArray<byte_r> PolygonMaterialIndices;
+        public SimpleArray<uint> MaterialColours;
+        public SimpleArray<byte> PolygonMaterialIndices;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -82,11 +82,11 @@ namespace RageLib.Resources.GTA5.PC.Bounds
                 this.MaterialsPointer, // offset
                 this.MaterialsCount
             );
-            this.MaterialColours = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.MaterialColours = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.MaterialColoursPointer, // offset
                 this.MaterialColoursCount
             );
-            this.PolygonMaterialIndices = reader.ReadBlockAt<ResourceSimpleArray<byte_r>>(
+            this.PolygonMaterialIndices = reader.ReadBlockAt<SimpleArray<byte>>(
                 this.PolygonMaterialIndicesPointer, // offset
                 this.PrimitivesCount
             );

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundPolyhedron.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundPolyhedron.cs
@@ -54,8 +54,8 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public ResourceSimpleArray<BoundVertex> Unknown_78h_Data;
         public ResourceSimpleArray<BoundPrimitive> Primitives;
         public ResourceSimpleArray<BoundVertex> Vertices;
-        public ResourceSimpleArray<uint_r> Unknown_B8h_Data;
-        public ResourceSimpleArray<uint_r> Unknown_C0h_Data;
+        public SimpleArray<uint> Unknown_B8h_Data;
+        public SimpleArray<uint> Unknown_C0h_Data;
         public ResourceSimpleArrayArray64<uint_r> Unknown_C8h_Data;
 
         /// <summary>
@@ -97,11 +97,11 @@ namespace RageLib.Resources.GTA5.PC.Bounds
                 this.VerticesPointer, // offset
                 this.VerticesCount2
             );
-            this.Unknown_B8h_Data = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.Unknown_B8h_Data = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.Unknown_B8h_Pointer, // offset
                 this.VerticesCount2
             );
-            this.Unknown_C0h_Data = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.Unknown_C0h_Data = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.Unknown_C0h_Pointer, // offset
                 8
             );

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundPolyhedron.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundPolyhedron.cs
@@ -22,6 +22,7 @@
 
 using RageLib.Resources.Common;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Bounds
 {
@@ -37,8 +38,8 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public uint Unknown_80h;
         public uint VerticesCount1;
         public ulong PrimitivesPointer;
-        public RAGE_Vector4 Quantum;
-        public RAGE_Vector4 Offset;
+        public Vector4 Quantum;
+        public Vector4 Offset;
         public ulong VerticesPointer;
         public ulong Unknown_B8h_Pointer;
         public ulong Unknown_C0h_Pointer;
@@ -71,8 +72,8 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             this.Unknown_80h = reader.ReadUInt32();
             this.VerticesCount1 = reader.ReadUInt32();
             this.PrimitivesPointer = reader.ReadUInt64();
-            this.Quantum = reader.ReadBlock<RAGE_Vector4>();
-            this.Offset = reader.ReadBlock<RAGE_Vector4>();
+            this.Quantum = reader.ReadVector4();
+            this.Offset = reader.ReadVector4();
             this.VerticesPointer = reader.ReadUInt64();
             this.Unknown_B8h_Pointer = reader.ReadUInt64();
             this.Unknown_C0h_Pointer = reader.ReadUInt64();
@@ -136,8 +137,8 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             writer.Write(this.Unknown_80h);
             writer.Write(this.VerticesCount1);
             writer.Write(this.PrimitivesPointer);
-            writer.WriteBlock(this.Quantum);
-            writer.WriteBlock(this.Offset);
+            writer.Write(this.Quantum);
+            writer.Write(this.Offset);
             writer.Write(this.VerticesPointer);
             writer.Write(this.Unknown_B8h_Pointer);
             writer.Write(this.Unknown_C0h_Pointer);

--- a/RageLib.GTA5/Resources/PC/Clips/Animation.cs
+++ b/RageLib.GTA5/Resources/PC/Clips/Animation.cs
@@ -51,7 +51,7 @@ namespace RageLib.Resources.GTA5.PC.Clips
         public uint Unknown_38h;
         public uint Unknown_3Ch;
         public ResourcePointerList64<Sequence> Sequences;
-        public ResourceSimpleList64<uint_r> Unknown_50h;
+        public SimpleList64<uint> Unknown_50h;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -78,7 +78,7 @@ namespace RageLib.Resources.GTA5.PC.Clips
             this.Unknown_38h = reader.ReadUInt32();
             this.Unknown_3Ch = reader.ReadUInt32();
             this.Sequences = reader.ReadBlock<ResourcePointerList64<Sequence>>();
-            this.Unknown_50h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_50h = reader.ReadBlock<SimpleList64<uint>>();
         }
 
         /// <summary>

--- a/RageLib.GTA5/Resources/PC/Clothes/CharacterCloth.cs
+++ b/RageLib.GTA5/Resources/PC/Clothes/CharacterCloth.cs
@@ -42,7 +42,7 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public ResourceSimpleList64<Unknown_C_001> Unknown_10h;
         public ulong ControllerPointer;
         public ulong BoundPointer;
-        public ResourceSimpleList64<uint_r> Unknown_30h;
+        public SimpleList64<uint> Unknown_30h;
         public uint Unknown_40h; // 0x00000000
         public uint Unknown_44h; // 0x00000000
         public uint Unknown_48h; // 0x00000000
@@ -63,7 +63,7 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public uint Unknown_84h; // 0x00000000
         public uint Unknown_88h; // 0x00000000
         public uint Unknown_8Ch; // 0x00000000
-        public ResourceSimpleList64<uint_r> Unknown_90h;
+        public SimpleList64<uint> Unknown_90h;
         public uint Unknown_A0h; // 0x00000000
         public uint Unknown_A4h; // 0x00000000
         public uint Unknown_A8h; // 0x00000000
@@ -94,7 +94,7 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Unknown_10h = reader.ReadBlock<ResourceSimpleList64<Unknown_C_001>>();
             this.ControllerPointer = reader.ReadUInt64();
             this.BoundPointer = reader.ReadUInt64();
-            this.Unknown_30h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_30h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_40h = reader.ReadUInt32();
             this.Unknown_44h = reader.ReadUInt32();
             this.Unknown_48h = reader.ReadUInt32();
@@ -115,7 +115,7 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Unknown_84h = reader.ReadUInt32();
             this.Unknown_88h = reader.ReadUInt32();
             this.Unknown_8Ch = reader.ReadUInt32();
-            this.Unknown_90h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_90h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_A0h = reader.ReadUInt32();
             this.Unknown_A4h = reader.ReadUInt32();
             this.Unknown_A8h = reader.ReadUInt32();

--- a/RageLib.GTA5/Resources/PC/Clothes/CharacterClothController.cs
+++ b/RageLib.GTA5/Resources/PC/Clothes/CharacterClothController.cs
@@ -32,19 +32,19 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public override long BlockLength => 0xF0;
 
         // structure data      
-        public ResourceSimpleList64<ushort_r> Unknown_80h;
+        public SimpleList64<ushort> Unknown_80h;
         public ResourceSimpleList64<Unknown_C_002> Unknown_90h;
         public uint Unknown_A0h; // 0x3D23D70A
         public uint Unknown_A4h; // 0x00000000
         public uint Unknown_A8h; // 0x00000000
         public uint Unknown_ACh; // 0x00000000
-        public ResourceSimpleList64<uint_r> Unknown_B0h;
+        public SimpleList64<uint> Unknown_B0h;
         public ResourceSimpleList64<Unknown_C_003> Unknown_C0h;
         public uint Unknown_D0h; // 0x00000000
         public uint Unknown_D4h; // 0x00000000
         public uint Unknown_D8h; // 0x00000000
         public uint Unknown_DCh; // 0x3F800000
-        public ResourceSimpleList64<uint_r> Unknown_E0h;
+        public SimpleList64<uint> Unknown_E0h;
         
         /// <summary>
         /// Reads the data-block from a stream.
@@ -54,19 +54,19 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             base.Read(reader, parameters);
 
             // read structure data         
-            this.Unknown_80h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
+            this.Unknown_80h = reader.ReadBlock<SimpleList64<ushort>>();
             this.Unknown_90h = reader.ReadBlock<ResourceSimpleList64<Unknown_C_002>>();
             this.Unknown_A0h = reader.ReadUInt32();
             this.Unknown_A4h = reader.ReadUInt32();
             this.Unknown_A8h = reader.ReadUInt32();
             this.Unknown_ACh = reader.ReadUInt32();
-            this.Unknown_B0h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_B0h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_C0h = reader.ReadBlock<ResourceSimpleList64<Unknown_C_003>>();
             this.Unknown_D0h = reader.ReadUInt32();
             this.Unknown_D4h = reader.ReadUInt32();
             this.Unknown_D8h = reader.ReadUInt32();
             this.Unknown_DCh = reader.ReadUInt32();
-            this.Unknown_E0h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_E0h = reader.ReadBlock<SimpleList64<uint>>();
         }
 
         /// <summary>

--- a/RageLib.GTA5/Resources/PC/Clothes/ClothBridgeSimGfx.cs
+++ b/RageLib.GTA5/Resources/PC/Clothes/ClothBridgeSimGfx.cs
@@ -40,37 +40,37 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public uint Unknown_14h;
         public uint Unknown_18h;
         public uint Unknown_1Ch; // 0x00000000
-        public ResourceSimpleList64<float_r> Unknown_20h;
-        public ResourceSimpleList64<float_r> Unknown_30h;
-        public ResourceSimpleList64<float_r> Unknown_40h;
+        public SimpleList64<float> Unknown_20h;
+        public SimpleList64<float> Unknown_30h;
+        public SimpleList64<float> Unknown_40h;
         public uint Unknown_50h; // 0x00000000
         public uint Unknown_54h; // 0x00000000
         public uint Unknown_58h; // 0x00000000
         public uint Unknown_5Ch; // 0x00000000
-        public ResourceSimpleList64<float_r> Unknown_60h;
-        public ResourceSimpleList64<uint_r> Unknown_70h;
-        public ResourceSimpleList64<uint_r> Unknown_80h;
+        public SimpleList64<float> Unknown_60h;
+        public SimpleList64<uint> Unknown_70h;
+        public SimpleList64<uint> Unknown_80h;
         public uint Unknown_90h; // 0x00000000
         public uint Unknown_94h; // 0x00000000
         public uint Unknown_98h; // 0x00000000
         public uint Unknown_9Ch; // 0x00000000
-        public ResourceSimpleList64<float_r> Unknown_A0h;
-        public ResourceSimpleList64<uint_r> Unknown_B0h;
-        public ResourceSimpleList64<uint_r> Unknown_C0h;
+        public SimpleList64<float> Unknown_A0h;
+        public SimpleList64<uint> Unknown_B0h;
+        public SimpleList64<uint> Unknown_C0h;
         public uint Unknown_D0h; // 0x00000000
         public uint Unknown_D4h; // 0x00000000
         public uint Unknown_D8h; // 0x00000000
         public uint Unknown_DCh; // 0x00000000
-        public ResourceSimpleList64<ushort_r> Unknown_E0h;
-        public ResourceSimpleList64<ushort_r> Unknown_F0h;
-        public ResourceSimpleList64<ushort_r> Unknown_100h;
+        public SimpleList64<ushort> Unknown_E0h;
+        public SimpleList64<ushort> Unknown_F0h;
+        public SimpleList64<ushort> Unknown_100h;
         public uint Unknown_110h; // 0x00000000
         public uint Unknown_114h; // 0x00000000
         public uint Unknown_118h; // 0x00000000
         public uint Unknown_11Ch; // 0x00000000
         public uint Unknown_120h; // 0x00000000
         public uint Unknown_124h; // 0x00000000
-        public ResourceSimpleList64<uint_r> Unknown_128h;
+        public SimpleList64<uint> Unknown_128h;
         public uint Unknown_138h; // 0x00000000
         public uint Unknown_13Ch; // 0x00000000
 
@@ -88,37 +88,37 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.Unknown_20h = reader.ReadBlock<ResourceSimpleList64<float_r>>();
-            this.Unknown_30h = reader.ReadBlock<ResourceSimpleList64<float_r>>();
-            this.Unknown_40h = reader.ReadBlock<ResourceSimpleList64<float_r>>();
+            this.Unknown_20h = reader.ReadBlock<SimpleList64<float>>();
+            this.Unknown_30h = reader.ReadBlock<SimpleList64<float>>();
+            this.Unknown_40h = reader.ReadBlock<SimpleList64<float>>();
             this.Unknown_50h = reader.ReadUInt32();
             this.Unknown_54h = reader.ReadUInt32();
             this.Unknown_58h = reader.ReadUInt32();
             this.Unknown_5Ch = reader.ReadUInt32();
-            this.Unknown_60h = reader.ReadBlock<ResourceSimpleList64<float_r>>();
-            this.Unknown_70h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
-            this.Unknown_80h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_60h = reader.ReadBlock<SimpleList64<float>>();
+            this.Unknown_70h = reader.ReadBlock<SimpleList64<uint>>();
+            this.Unknown_80h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_90h = reader.ReadUInt32();
             this.Unknown_94h = reader.ReadUInt32();
             this.Unknown_98h = reader.ReadUInt32();
             this.Unknown_9Ch = reader.ReadUInt32();
-            this.Unknown_A0h = reader.ReadBlock<ResourceSimpleList64<float_r>>();
-            this.Unknown_B0h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
-            this.Unknown_C0h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_A0h = reader.ReadBlock<SimpleList64<float>>();
+            this.Unknown_B0h = reader.ReadBlock<SimpleList64<uint>>();
+            this.Unknown_C0h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_D0h = reader.ReadUInt32();
             this.Unknown_D4h = reader.ReadUInt32();
             this.Unknown_D8h = reader.ReadUInt32();
             this.Unknown_DCh = reader.ReadUInt32();
-            this.Unknown_E0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_F0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_100h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
+            this.Unknown_E0h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_F0h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_100h = reader.ReadBlock<SimpleList64<ushort>>();
             this.Unknown_110h = reader.ReadUInt32();
             this.Unknown_114h = reader.ReadUInt32();
             this.Unknown_118h = reader.ReadUInt32();
             this.Unknown_11Ch = reader.ReadUInt32();
             this.Unknown_120h = reader.ReadUInt32();
             this.Unknown_124h = reader.ReadUInt32();
-            this.Unknown_128h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_128h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_138h = reader.ReadUInt32();
             this.Unknown_13Ch = reader.ReadUInt32();
         }

--- a/RageLib.GTA5/Resources/PC/Clothes/ClothDictionary.cs
+++ b/RageLib.GTA5/Resources/PC/Clothes/ClothDictionary.cs
@@ -37,7 +37,7 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public uint Unknown_14h; // 0x00000000
         public uint Unknown_18h; // 0x00000001
         public uint Unknown_1Ch; // 0x00000000
-        public ResourceSimpleList64<uint_r> ClothNameHashes;
+        public SimpleList64<uint> ClothNameHashes;
         public ResourcePointerList64<CharacterCloth> Clothes;
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.ClothNameHashes = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.ClothNameHashes = reader.ReadBlock<SimpleList64<uint>>();
             this.Clothes = reader.ReadBlock<ResourcePointerList64<CharacterCloth>>();
         }
 

--- a/RageLib.GTA5/Resources/PC/Clothes/EnvironmentCloth.cs
+++ b/RageLib.GTA5/Resources/PC/Clothes/EnvironmentCloth.cs
@@ -68,7 +68,7 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public ClothInstanceTuning InstanceTuning;
         public FragDrawable Drawable;
         public ClothController Controller;
-        public ResourceSimpleArray<uint_r> pxxxxx_2data;
+        public SimpleArray<uint> pxxxxx_2data;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -116,7 +116,7 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Controller = reader.ReadBlockAt<ClothController>(
                 this.ControllerPointer // offset
             );
-            this.pxxxxx_2data = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.pxxxxx_2data = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.pxxxxx_2, // offset
                 this.cntxx51a
             );

--- a/RageLib.GTA5/Resources/PC/Clothes/Unknown_C_006.cs
+++ b/RageLib.GTA5/Resources/PC/Clothes/Unknown_C_006.cs
@@ -52,15 +52,15 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public uint Unknown_48h; // 0x00000000
         public uint Unknown_4Ch; // 0x00000000
         public SimpleList64<Vector4> Unknown_50h;
-        public ResourceSimpleList64<ushort_r> Unknown_60h;
-        public ResourceSimpleList64<ushort_r> Unknown_70h;
-        public ResourceSimpleList64<ushort_r> Unknown_80h;
-        public ResourceSimpleList64<ushort_r> Unknown_90h;
+        public SimpleList64<ushort> Unknown_60h;
+        public SimpleList64<ushort> Unknown_70h;
+        public SimpleList64<ushort> Unknown_80h;
+        public SimpleList64<ushort> Unknown_90h;
         public SimpleList64<Vector4> Unknown_A0h;
-        public ResourceSimpleList64<ushort_r> Unknown_B0h;
-        public ResourceSimpleList64<ushort_r> Unknown_C0h;
-        public ResourceSimpleList64<ushort_r> Unknown_D0h;
-        public ResourceSimpleList64<ushort_r> Unknown_E0h;
+        public SimpleList64<ushort> Unknown_B0h;
+        public SimpleList64<ushort> Unknown_C0h;
+        public SimpleList64<ushort> Unknown_D0h;
+        public SimpleList64<ushort> Unknown_E0h;
         public uint Unknown_F0h; // 0x00000000
         public uint Unknown_F4h; // 0x00000000
         public uint Unknown_F8h; // 0x00000000
@@ -85,8 +85,8 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public uint Unknown_144h; // 0x00000000
         public uint Unknown_148h; // 0x00000000
         public uint Unknown_14Ch; // 0x00000000
-        public ResourceSimpleList64<ushort_r> Unknown_150h;
-        public ResourceSimpleList64<ushort_r> Unknown_160h;
+        public SimpleList64<ushort> Unknown_150h;
+        public SimpleList64<ushort> Unknown_160h;
         public uint Unknown_170h; // 0x00000000
         public uint Unknown_174h; // 0x00000000
         public uint Unknown_178h; // 0x00000000
@@ -123,15 +123,15 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Unknown_48h = reader.ReadUInt32();
             this.Unknown_4Ch = reader.ReadUInt32();
             this.Unknown_50h = reader.ReadBlock<SimpleList64<Vector4>>();
-            this.Unknown_60h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_70h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_80h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_90h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
+            this.Unknown_60h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_70h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_80h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_90h = reader.ReadBlock<SimpleList64<ushort>>();
             this.Unknown_A0h = reader.ReadBlock<SimpleList64<Vector4>>();
-            this.Unknown_B0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_C0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_D0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_E0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
+            this.Unknown_B0h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_C0h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_D0h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_E0h = reader.ReadBlock<SimpleList64<ushort>>();
             this.Unknown_F0h = reader.ReadUInt32();
             this.Unknown_F4h = reader.ReadUInt32();
             this.Unknown_F8h = reader.ReadUInt32();
@@ -156,8 +156,8 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Unknown_144h = reader.ReadUInt32();
             this.Unknown_148h = reader.ReadUInt32();
             this.Unknown_14Ch = reader.ReadUInt32();
-            this.Unknown_150h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_160h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
+            this.Unknown_150h = reader.ReadBlock<SimpleList64<ushort>>();
+            this.Unknown_160h = reader.ReadBlock<SimpleList64<ushort>>();
             this.Unknown_170h = reader.ReadUInt32();
             this.Unknown_174h = reader.ReadUInt32();
             this.Unknown_178h = reader.ReadUInt32();

--- a/RageLib.GTA5/Resources/PC/Clothes/Unknown_C_006.cs
+++ b/RageLib.GTA5/Resources/PC/Clothes/Unknown_C_006.cs
@@ -22,6 +22,7 @@
 
 using RageLib.Resources.Common;
 using System;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Clothes
 {
@@ -50,12 +51,12 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public uint Unknown_44h; // 0x00000000
         public uint Unknown_48h; // 0x00000000
         public uint Unknown_4Ch; // 0x00000000
-        public ResourceSimpleList64<RAGE_Vector4> Unknown_50h;
+        public SimpleList64<Vector4> Unknown_50h;
         public ResourceSimpleList64<ushort_r> Unknown_60h;
         public ResourceSimpleList64<ushort_r> Unknown_70h;
         public ResourceSimpleList64<ushort_r> Unknown_80h;
         public ResourceSimpleList64<ushort_r> Unknown_90h;
-        public ResourceSimpleList64<RAGE_Vector4> Unknown_A0h;
+        public SimpleList64<Vector4> Unknown_A0h;
         public ResourceSimpleList64<ushort_r> Unknown_B0h;
         public ResourceSimpleList64<ushort_r> Unknown_C0h;
         public ResourceSimpleList64<ushort_r> Unknown_D0h;
@@ -121,12 +122,12 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Unknown_44h = reader.ReadUInt32();
             this.Unknown_48h = reader.ReadUInt32();
             this.Unknown_4Ch = reader.ReadUInt32();
-            this.Unknown_50h = reader.ReadBlock<ResourceSimpleList64<RAGE_Vector4>>();
+            this.Unknown_50h = reader.ReadBlock<SimpleList64<Vector4>>();
             this.Unknown_60h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
             this.Unknown_70h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
             this.Unknown_80h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
             this.Unknown_90h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
-            this.Unknown_A0h = reader.ReadBlock<ResourceSimpleList64<RAGE_Vector4>>();
+            this.Unknown_A0h = reader.ReadBlock<SimpleList64<Vector4>>();
             this.Unknown_B0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
             this.Unknown_C0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();
             this.Unknown_D0h = reader.ReadBlock<ResourceSimpleList64<ushort_r>>();

--- a/RageLib.GTA5/Resources/PC/Clothes/VerletCloth.cs
+++ b/RageLib.GTA5/Resources/PC/Clothes/VerletCloth.cs
@@ -24,6 +24,7 @@ using RageLib.Resources.Common;
 using RageLib.Resources.GTA5.PC.Bounds;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Clothes
 {
@@ -61,8 +62,8 @@ namespace RageLib.Resources.GTA5.PC.Clothes
         public uint Unknown_64h; // 0x00000000
         public uint Unknown_68h; // 0x00000000
         public uint Unknown_6Ch; // 0x00000000
-        public ResourceSimpleList64<RAGE_Vector4> Unknown_70h;
-        public ResourceSimpleList64<RAGE_Vector4> Unknown_80h;
+        public SimpleList64<Vector4> Unknown_70h;
+        public SimpleList64<Vector4> Unknown_80h;
         public uint Unknown_90h; // 0x00000000
         public uint Unknown_94h; // 0x00000000
         public uint Unknown_98h; // 0x00000000
@@ -154,8 +155,8 @@ namespace RageLib.Resources.GTA5.PC.Clothes
             this.Unknown_64h = reader.ReadUInt32();
             this.Unknown_68h = reader.ReadUInt32();
             this.Unknown_6Ch = reader.ReadUInt32();
-            this.Unknown_70h = reader.ReadBlock<ResourceSimpleList64<RAGE_Vector4>>();
-            this.Unknown_80h = reader.ReadBlock<ResourceSimpleList64<RAGE_Vector4>>();
+            this.Unknown_70h = reader.ReadBlock<SimpleList64<Vector4>>();
+            this.Unknown_80h = reader.ReadBlock<SimpleList64<Vector4>>();
             this.Unknown_90h = reader.ReadUInt32();
             this.Unknown_94h = reader.ReadUInt32();
             this.Unknown_98h = reader.ReadUInt32();

--- a/RageLib.GTA5/Resources/PC/Drawables/Bone.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/Bone.cs
@@ -24,6 +24,7 @@ using RageLib.Hash;
 using RageLib.Resources.Common;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Drawables
 {
@@ -33,10 +34,10 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         public override long BlockLength => 0x50;
 
         // structure data
-        public RAGE_Vector4 Rotation;
-        public RAGE_Vector3 Translation;
+        public Quaternion Rotation;
+        public Vector3 Translation;
         public uint Unknown_1Ch; // 0x00000000
-        public RAGE_Vector3 Scale;
+        public Vector3 Scale;
         public float Unknown_2Ch; // 1.0
         public ushort NextSiblingIndex;
         public ushort ParentIndex;
@@ -58,10 +59,10 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         public override void Read(ResourceDataReader reader, params object[] parameters)
         {
             // read structure data
-            this.Rotation = reader.ReadBlock<RAGE_Vector4>();
-            this.Translation = reader.ReadBlock<RAGE_Vector3>();
+            this.Rotation = reader.ReadQuaternion();
+            this.Translation = reader.ReadVector3();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.Scale = reader.ReadBlock<RAGE_Vector3>();
+            this.Scale = reader.ReadVector3();
             this.Unknown_2Ch = reader.ReadSingle();
             this.NextSiblingIndex = reader.ReadUInt16();
             this.ParentIndex = reader.ReadUInt16();
@@ -89,10 +90,10 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             this.NamePointer = (ulong)(this.Name != null ? this.Name.BlockPosition : 0);
 
             // write structure data
-            writer.WriteBlock(this.Rotation);
-            writer.WriteBlock(this.Translation);
+            writer.Write(this.Rotation);
+            writer.Write(this.Translation);
             writer.Write(this.Unknown_1Ch);
-            writer.WriteBlock(this.Scale);
+            writer.Write(this.Scale);
             writer.Write(this.Unknown_2Ch);
             writer.Write(this.NextSiblingIndex);
             writer.Write(this.ParentIndex);

--- a/RageLib.GTA5/Resources/PC/Drawables/DrawableGeometry.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/DrawableGeometry.cs
@@ -61,7 +61,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         // reference data
         public VertexBuffer VertexBuffer;
         public IndexBuffer IndexBuffer;
-        public ResourceSimpleArray<ushort_r> BonesId;
+        public SimpleArray<ushort> BonesId;
         public VertexData_GTA5_pc VertexData;
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             this.IndexBuffer = reader.ReadBlockAt<IndexBuffer>(
                 this.IndexBufferPointer // offset
             );
-            this.BonesId = reader.ReadBlockAt<ResourceSimpleArray<ushort_r>>(
+            this.BonesId = reader.ReadBlockAt<SimpleArray<ushort>>(
                 this.BonesIdPointer, // offset
                 this.BonesCount
             );

--- a/RageLib.GTA5/Resources/PC/Drawables/DrawableModel.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/DrawableModel.cs
@@ -42,7 +42,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
 
         // reference data
         public ResourceSimpleArray<RAGE_AABB> GeometriesBounds;
-        public ResourceSimpleArray<ushort_r> ShaderMapping;
+        public SimpleArray<ushort> ShaderMapping;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -64,7 +64,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
                 this.GeometriesBoundsPointer, // offset
                 this.GeometriesCount > 1 ? this.GeometriesCount + 1 : this.GeometriesCount
             );
-            this.ShaderMapping = reader.ReadBlockAt<ResourceSimpleArray<ushort_r>>(
+            this.ShaderMapping = reader.ReadBlockAt<SimpleArray<ushort>>(
                 this.ShaderMappingPointer, // offset
                 this.GeometriesCount
             );

--- a/RageLib.GTA5/Resources/PC/Drawables/JointTranslationLimit.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/JointTranslationLimit.cs
@@ -21,6 +21,7 @@
 */
 
 using RageLib.Resources.Common;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Drawables
 {
@@ -37,9 +38,9 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         public uint Unknown_14h; // 0x00000000
         public uint Unknown_18h; // 0x00000000
         public uint Unknown_1Ch; // 0x00000000
-        public RAGE_Vector3 Min;
+        public Vector3 Min;
         public uint Unknown_2Ch; // 0x00000000
-        public RAGE_Vector3 Max;
+        public Vector3 Max;
         public uint Unknown_3Ch; // 0x00000000
 
         /// <summary>
@@ -56,9 +57,9 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.Min = reader.ReadBlock<RAGE_Vector3>();
+            this.Min = reader.ReadVector3();
             this.Unknown_2Ch = reader.ReadUInt32();
-            this.Max = reader.ReadBlock<RAGE_Vector3>();
+            this.Max = reader.ReadVector3();
             this.Unknown_3Ch = reader.ReadUInt32();
         }
 
@@ -76,9 +77,9 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             writer.Write(this.Unknown_14h);
             writer.Write(this.Unknown_18h);
             writer.Write(this.Unknown_1Ch);
-            writer.WriteBlock(this.Min);
+            writer.Write(this.Min);
             writer.Write(this.Unknown_2Ch);
-            writer.WriteBlock(this.Max);
+            writer.Write(this.Max);
             writer.Write(this.Unknown_3Ch);
         }
     }

--- a/RageLib.GTA5/Resources/PC/Drawables/LightAttributes.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/LightAttributes.cs
@@ -21,6 +21,7 @@
 */
 
 using RageLib.Resources.Common;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Drawables
 {
@@ -32,7 +33,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         // structure data
         public uint Unknown_0h; // 0x00000000
         public uint Unknown_4h; // 0x00000000
-        public RAGE_Vector3 Position;
+        public Vector3 Position;
         public uint Unknown_14h; // 0x00000000
         public byte ColorR;
         public byte ColorG;
@@ -46,7 +47,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         public uint TimeFlags;
         public float Falloff;
         public float FalloffExponent;
-        public RAGE_Vector3 CullingPlaneNormal;
+        public Vector3 CullingPlaneNormal;
         public float CullingPlaneOffset;
         public byte ShadowBlur;
         public byte Unknown_45h;
@@ -68,11 +69,11 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         public float ShadowNearClip;
         public float CoronaIntensity;
         public float CoronaZBias;
-        public RAGE_Vector3 Direction;
-        public RAGE_Vector3 Tangent;
+        public Vector3 Direction;
+        public Vector3 Tangent;
         public float ConeInnerAngle;
         public float ConeOuterAngle;
-        public RAGE_Vector3 Extent;
+        public Vector3 Extent;
         public uint ProjectedTextureHash;
         public uint Unknown_A4h; // 0x00000000
 
@@ -84,7 +85,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             // read structure data
             this.Unknown_0h = reader.ReadUInt32();
             this.Unknown_4h = reader.ReadUInt32();
-            this.Position = reader.ReadBlock<RAGE_Vector3>();
+            this.Position = reader.ReadVector3();
             this.Unknown_14h = reader.ReadUInt32();
             this.ColorR = reader.ReadByte();
             this.ColorG = reader.ReadByte();
@@ -98,7 +99,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             this.TimeFlags = reader.ReadUInt32();
             this.Falloff = reader.ReadSingle();
             this.FalloffExponent = reader.ReadSingle();
-            this.CullingPlaneNormal = reader.ReadBlock<RAGE_Vector3>();
+            this.CullingPlaneNormal = reader.ReadVector3();
             this.CullingPlaneOffset = reader.ReadSingle();
             this.ShadowBlur = reader.ReadByte();
             this.Unknown_45h = reader.ReadByte();
@@ -120,11 +121,11 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             this.ShadowNearClip = reader.ReadSingle();
             this.CoronaIntensity = reader.ReadSingle();
             this.CoronaZBias = reader.ReadSingle();
-            this.Direction = reader.ReadBlock<RAGE_Vector3>();
-            this.Tangent = reader.ReadBlock<RAGE_Vector3>();
+            this.Direction = reader.ReadVector3();
+            this.Tangent = reader.ReadVector3();
             this.ConeInnerAngle = reader.ReadSingle();
             this.ConeOuterAngle = reader.ReadSingle();
-            this.Extent = reader.ReadBlock<RAGE_Vector3>();
+            this.Extent = reader.ReadVector3();
             this.ProjectedTextureHash = reader.ReadUInt32();
             this.Unknown_A4h = reader.ReadUInt32();
         }
@@ -137,7 +138,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             // write structure data
             writer.Write(this.Unknown_0h);
             writer.Write(this.Unknown_4h);
-            writer.WriteBlock(this.Position);
+            writer.Write(this.Position);
             writer.Write(this.Unknown_14h);
             writer.Write(this.ColorR);
             writer.Write(this.ColorG);
@@ -151,7 +152,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             writer.Write(this.TimeFlags);
             writer.Write(this.Falloff);
             writer.Write(this.FalloffExponent);
-            writer.WriteBlock(this.CullingPlaneNormal);
+            writer.Write(this.CullingPlaneNormal);
             writer.Write(this.CullingPlaneOffset);
             writer.Write(this.ShadowBlur);
             writer.Write(this.Unknown_45h);
@@ -173,11 +174,11 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             writer.Write(this.ShadowNearClip);
             writer.Write(this.CoronaIntensity);
             writer.Write(this.CoronaZBias);
-            writer.WriteBlock(this.Direction);
-            writer.WriteBlock(this.Tangent);
+            writer.Write(this.Direction);
+            writer.Write(this.Tangent);
             writer.Write(this.ConeInnerAngle);
             writer.Write(this.ConeOuterAngle);
-            writer.WriteBlock(this.Extent);
+            writer.Write(this.Extent);
             writer.Write(this.ProjectedTextureHash);
             writer.Write(this.Unknown_A4h);
         }

--- a/RageLib.GTA5/Resources/PC/Drawables/LodGroup.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/LodGroup.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -13,10 +14,10 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         public override long BlockLength => 0x70;
 
         // structure data
-        public RAGE_Vector3 BoundingCenter;
+        public Vector3 BoundingCenter;
         public float BoundingSphereRadius;
-        public RAGE_Vector4 BoundingBoxMin;
-        public RAGE_Vector4 BoundingBoxMax;
+        public Vector4 BoundingBoxMin;
+        public Vector4 BoundingBoxMax;
         public ulong DrawableModelsHighPointer;
         public ulong DrawableModelsMediumPointer;
         public ulong DrawableModelsLowPointer;
@@ -42,10 +43,10 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         public override void Read(ResourceDataReader reader, params object[] parameters)
         {
             // read structure data
-            this.BoundingCenter = reader.ReadBlock<RAGE_Vector3>();
+            this.BoundingCenter = reader.ReadVector3();
             this.BoundingSphereRadius = reader.ReadSingle();
-            this.BoundingBoxMin = reader.ReadBlock<RAGE_Vector4>();
-            this.BoundingBoxMax = reader.ReadBlock<RAGE_Vector4>();
+            this.BoundingBoxMin = reader.ReadVector4();
+            this.BoundingBoxMax = reader.ReadVector4();
             this.DrawableModelsHighPointer = reader.ReadUInt64();
             this.DrawableModelsMediumPointer = reader.ReadUInt64();
             this.DrawableModelsLowPointer = reader.ReadUInt64();
@@ -87,10 +88,10 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             this.DrawableModelsVeryLowPointer = (ulong)(this.DrawableModelsVeryLow != null ? this.DrawableModelsVeryLow.BlockPosition : 0);
 
             // write structure data
-            writer.WriteBlock(this.BoundingCenter);
+            writer.Write(this.BoundingCenter);
             writer.Write(this.BoundingSphereRadius);
-            writer.WriteBlock(this.BoundingBoxMin);
-            writer.WriteBlock(this.BoundingBoxMax);
+            writer.Write(this.BoundingBoxMin);
+            writer.Write(this.BoundingBoxMax);
             writer.Write(this.DrawableModelsHighPointer);
             writer.Write(this.DrawableModelsMediumPointer);
             writer.Write(this.DrawableModelsLowPointer);

--- a/RageLib.GTA5/Resources/PC/Drawables/ShaderFX.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/ShaderFX.cs
@@ -179,7 +179,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
 
         public ResourceSimpleArray<ShaderParameter> Parameters;
         public ResourceSimpleArray<SimpleArray<Vector4>> Data;
-        public ResourceSimpleArray<uint_r> Hashes;
+        public SimpleArray<uint> Hashes;
         // Hashes alignment pad
         // Extra 32 bytes 
         // Extra 4 * ParametersTotalSize bytes
@@ -233,7 +233,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             // Skip Data among Parameters and Hashes which we have already read
             reader.Position += dataBlockSize;
 
-            Hashes = reader.ReadBlock<ResourceSimpleArray<uint_r>>(cnt);
+            Hashes = reader.ReadBlock<SimpleArray<uint>>(cnt);
 
             // Read hashes alignment pad
             //reader.Position += (16 - (reader.Position % 16)) % 16;
@@ -268,9 +268,9 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             }
 
             // write hashes
-            foreach (var h in Hashes)
-                writer.WriteBlock(h); 
-            //writer.WriteBlock(Hashes);
+            //foreach (var h in Hashes)
+            //    writer.WriteBlock(h); 
+            writer.WriteBlock(Hashes);
 
             // Write hashes alignment pad
             var pad = (16 - (writer.Position % 16)) % 16;

--- a/RageLib.GTA5/Resources/PC/Drawables/ShaderFX.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/ShaderFX.cs
@@ -24,6 +24,7 @@ using RageLib.Resources.Common;
 using RageLib.Resources.GTA5.PC.Textures;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Drawables
 {
@@ -177,7 +178,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         }
 
         public ResourceSimpleArray<ShaderParameter> Parameters;
-        public ResourceSimpleArray<ResourceSimpleArray<RAGE_Vector4>> Data;
+        public ResourceSimpleArray<SimpleArray<Vector4>> Data;
         public ResourceSimpleArray<uint_r> Hashes;
         // Hashes alignment pad
         // Extra 32 bytes 
@@ -188,7 +189,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
             int cnt = Convert.ToInt32(parameters[0]);
 
             Parameters = reader.ReadBlock<ResourceSimpleArray<ShaderParameter>>(cnt);
-            Data = new ResourceSimpleArray<ResourceSimpleArray<RAGE_Vector4>>();
+            Data = new ResourceSimpleArray<SimpleArray<Vector4>>();
             int dataBlockSize = 0;
             for (int i = 0; i < cnt; i++)
             {
@@ -222,7 +223,7 @@ namespace RageLib.Resources.GTA5.PC.Drawables
 
                     default:
                         dataBlockSize += 16 * p.DataType;
-                        var data = reader.ReadBlockAt<ResourceSimpleArray<RAGE_Vector4>>(p.DataPointer, p.DataType);
+                        var data = reader.ReadBlockAt<SimpleArray<Vector4>>(p.DataPointer, p.DataType);
                         p.Data = data;
                         Data.Add(data);
                         break;

--- a/RageLib.GTA5/Resources/PC/Drawables/SkeletonData.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/SkeletonData.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using RageLib.GTA5.Resources.PC.Drawables;
 using RageLib.Resources.Common;
 
@@ -53,8 +54,8 @@ namespace RageLib.Resources.GTA5.PC.Drawables
 
         // reference data
         public BoneData BoneData;
-        public ResourceSimpleArray<RAGE_Matrix4x4> TransformationsInverted;
-        public ResourceSimpleArray<RAGE_Matrix4x4> Transformations;
+        public SimpleArray<Matrix4x4> TransformationsInverted;
+        public SimpleArray<Matrix4x4> Transformations;
         public ResourceSimpleArray<ushort_r> ParentIndices;
         public ResourceSimpleArray<ushort_r> ChildrenIndices;
 
@@ -88,11 +89,11 @@ namespace RageLib.Resources.GTA5.PC.Drawables
                 this.BoneDataPointer - 16, // offset
                 this.BonesCount
             );
-            this.TransformationsInverted = reader.ReadBlockAt<ResourceSimpleArray<RAGE_Matrix4x4>>(
+            this.TransformationsInverted = reader.ReadBlockAt<SimpleArray<Matrix4x4>>(
                 this.TransformationsInvertedPointer, // offset
                 this.BonesCount
             );
-            this.Transformations = reader.ReadBlockAt<ResourceSimpleArray<RAGE_Matrix4x4>>(
+            this.Transformations = reader.ReadBlockAt<SimpleArray<Matrix4x4>>(
                 this.TransformationsPointer, // offset
                 this.BonesCount
             );

--- a/RageLib.GTA5/Resources/PC/Drawables/SkeletonData.cs
+++ b/RageLib.GTA5/Resources/PC/Drawables/SkeletonData.cs
@@ -56,8 +56,8 @@ namespace RageLib.Resources.GTA5.PC.Drawables
         public BoneData BoneData;
         public SimpleArray<Matrix4x4> TransformationsInverted;
         public SimpleArray<Matrix4x4> Transformations;
-        public ResourceSimpleArray<ushort_r> ParentIndices;
-        public ResourceSimpleArray<ushort_r> ChildrenIndices;
+        public SimpleArray<ushort> ParentIndices;
+        public SimpleArray<ushort> ChildrenIndices;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -97,11 +97,11 @@ namespace RageLib.Resources.GTA5.PC.Drawables
                 this.TransformationsPointer, // offset
                 this.BonesCount
             );
-            this.ParentIndices = reader.ReadBlockAt<ResourceSimpleArray<ushort_r>>(
+            this.ParentIndices = reader.ReadBlockAt<SimpleArray<ushort>>(
                 this.ParentIndicesPointer, // offset
                 this.BonesCount
             );
-            this.ChildrenIndices = reader.ReadBlockAt<ResourceSimpleArray<ushort_r>>(
+            this.ChildrenIndices = reader.ReadBlockAt<SimpleArray<ushort>>(
                 this.ChildrenIndicesPointer, // offset
                 this.ChildrenIndicesCount
             );

--- a/RageLib.GTA5/Resources/PC/Expressions/Expression.cs
+++ b/RageLib.GTA5/Resources/PC/Expressions/Expression.cs
@@ -42,9 +42,9 @@ namespace RageLib.Resources.GTA5.PC.Expressions
         public uint Unknown_18h;
         public uint Unknown_1Ch;
         public ResourcePointerList64<Unknown_E_001> Unknown_20h;
-        public ResourceSimpleList64<uint_r> Unknown_30h;
+        public SimpleList64<uint> Unknown_30h;
         public ResourceSimpleList64<Unknown_E_002> Unknown_40h;
-        public ResourceSimpleList64<uint_r> Unknown_50h;
+        public SimpleList64<uint> Unknown_50h;
         public ulong NamePointer;
         public uint Unknown_68h; // short, short, (name len, name len+1)
         public uint Unknown_6Ch;
@@ -76,9 +76,9 @@ namespace RageLib.Resources.GTA5.PC.Expressions
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
             this.Unknown_20h = reader.ReadBlock<ResourcePointerList64<Unknown_E_001>>();
-            this.Unknown_30h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_30h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_40h = reader.ReadBlock<ResourceSimpleList64<Unknown_E_002>>();
-            this.Unknown_50h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_50h = reader.ReadBlock<SimpleList64<uint>>();
             this.NamePointer = reader.ReadUInt64();
             this.Unknown_68h = reader.ReadUInt32();
             this.Unknown_6Ch = reader.ReadUInt32();

--- a/RageLib.GTA5/Resources/PC/Expressions/ExpressionDictionary.cs
+++ b/RageLib.GTA5/Resources/PC/Expressions/ExpressionDictionary.cs
@@ -37,7 +37,7 @@ namespace RageLib.Resources.GTA5.PC.Expressions
         public uint Unknown_14h;
         public uint Unknown_18h;
         public uint Unknown_1Ch;
-        public ResourceSimpleList64<uint_r> ExpressionNameHashes;
+        public SimpleList64<uint> ExpressionNameHashes;
         public ResourcePointerList64<Expression> Expressions;
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace RageLib.Resources.GTA5.PC.Expressions
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.ExpressionNameHashes = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.ExpressionNameHashes = reader.ReadBlock<SimpleList64<uint>>();
             this.Expressions = reader.ReadBlock<ResourcePointerList64<Expression>>();
         }
 

--- a/RageLib.GTA5/Resources/PC/Filters/Filter.cs
+++ b/RageLib.GTA5/Resources/PC/Filters/Filter.cs
@@ -37,8 +37,8 @@ namespace RageLib.Resources
         public uint Unknown_Ch;
         public uint Unknown_10h; // 0x00000004
         public uint Unknown_14h; // 0x00000000
-        public ResourceSimpleList64<ulong_r> Unknown_18h;
-        public ResourceSimpleList64<uint_r> Unknown_28h;
+        public SimpleList64<ulong> Unknown_18h;
+        public SimpleList64<uint> Unknown_28h;
         public uint Unknown_38h; // 0x00000000
         public uint Unknown_3Ch; // 0x00000000
 
@@ -54,8 +54,8 @@ namespace RageLib.Resources
             this.Unknown_Ch = reader.ReadUInt32();
             this.Unknown_10h = reader.ReadUInt32();
             this.Unknown_14h = reader.ReadUInt32();
-            this.Unknown_18h = reader.ReadBlock<ResourceSimpleList64<ulong_r>>();
-            this.Unknown_28h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_18h = reader.ReadBlock<SimpleList64<ulong>>();
+            this.Unknown_28h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_38h = reader.ReadUInt32();
             this.Unknown_3Ch = reader.ReadUInt32();
         }

--- a/RageLib.GTA5/Resources/PC/Filters/FilterDictionary.cs
+++ b/RageLib.GTA5/Resources/PC/Filters/FilterDictionary.cs
@@ -36,7 +36,7 @@ namespace RageLib.Resources
         public uint Unknown_14h; // 0x00000000
         public uint Unknown_18h; // 0x00000001
         public uint Unknown_1Ch; // 0x00000000
-        public ResourceSimpleList64<uint_r> FilterNameHashes;
+        public SimpleList64<uint> FilterNameHashes;
         public ResourcePointerList64<Filter> Filters;
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace RageLib.Resources
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.FilterNameHashes = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.FilterNameHashes = reader.ReadBlock<SimpleList64<uint>>();
             this.Filters = reader.ReadBlock<ResourcePointerList64<Filter>>();
         }
 

--- a/RageLib.GTA5/Resources/PC/Fragments/Archetype.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/Archetype.cs
@@ -23,6 +23,7 @@
 using RageLib.Resources.Common;
 using RageLib.Resources.GTA5.PC.Bounds;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Fragments
 {
@@ -54,14 +55,14 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public float Unknown_54h; // 1.0f
         public uint Unknown_58h; // 0x00000000
         public uint Unknown_5Ch; // 0x00000000
-        public RAGE_Vector4 Unknown_60h;
-        public RAGE_Vector4 Unknown_70h;
-        public RAGE_Vector4 Unknown_80h; // 0.0 0.0 0.0 NaN
-        public RAGE_Vector4 Unknown_90h; // 0.0 0.0 0.0 NaN
-        public RAGE_Vector4 Unknown_A0h; // 0.0 0.0 0.0 NaN
-        public RAGE_Vector4 Unknown_B0h; // 0.0 0.0 0.0 NaN
-        public RAGE_Vector4 Unknown_C0h; // 0.0 0.0 0.0 NaN
-        public RAGE_Vector4 Unknown_D0h; // 0.0 0.0 0.0 NaN
+        public Vector4 Unknown_60h;
+        public Vector4 Unknown_70h;
+        public Vector4 Unknown_80h; // 0.0 0.0 0.0 NaN
+        public Vector4 Unknown_90h; // 0.0 0.0 0.0 NaN
+        public Vector4 Unknown_A0h; // 0.0 0.0 0.0 NaN
+        public Vector4 Unknown_B0h; // 0.0 0.0 0.0 NaN
+        public Vector4 Unknown_C0h; // 0.0 0.0 0.0 NaN
+        public Vector4 Unknown_D0h; // 0.0 0.0 0.0 NaN
 
         // reference data
         public string_r Name;
@@ -93,14 +94,14 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.Unknown_54h = reader.ReadSingle();
             this.Unknown_58h = reader.ReadUInt32();
             this.Unknown_5Ch = reader.ReadUInt32();
-            this.Unknown_60h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_70h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_80h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_90h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_A0h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_B0h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_C0h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_D0h = reader.ReadBlock<RAGE_Vector4>();
+            this.Unknown_60h = reader.ReadVector4();
+            this.Unknown_70h = reader.ReadVector4();
+            this.Unknown_80h = reader.ReadVector4();
+            this.Unknown_90h = reader.ReadVector4();
+            this.Unknown_A0h = reader.ReadVector4();
+            this.Unknown_B0h = reader.ReadVector4();
+            this.Unknown_C0h = reader.ReadVector4();
+            this.Unknown_D0h = reader.ReadVector4();
 
             // read reference data
             this.Name = reader.ReadBlockAt<string_r>(
@@ -141,14 +142,14 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             writer.Write(this.Unknown_54h);
             writer.Write(this.Unknown_58h);
             writer.Write(this.Unknown_5Ch);
-            writer.WriteBlock(this.Unknown_60h);
-            writer.WriteBlock(this.Unknown_70h);
-            writer.WriteBlock(this.Unknown_80h);
-            writer.WriteBlock(this.Unknown_90h);
-            writer.WriteBlock(this.Unknown_A0h);
-            writer.WriteBlock(this.Unknown_B0h);
-            writer.WriteBlock(this.Unknown_C0h);
-            writer.WriteBlock(this.Unknown_D0h);
+            writer.Write(this.Unknown_60h);
+            writer.Write(this.Unknown_70h);
+            writer.Write(this.Unknown_80h);
+            writer.Write(this.Unknown_90h);
+            writer.Write(this.Unknown_A0h);
+            writer.Write(this.Unknown_B0h);
+            writer.Write(this.Unknown_C0h);
+            writer.Write(this.Unknown_D0h);
         }
 
         /// <summary>

--- a/RageLib.GTA5/Resources/PC/Fragments/ArticulatedBodyType.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/ArticulatedBodyType.cs
@@ -22,6 +22,7 @@
 
 using RageLib.Resources.Common;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Fragments
 {
@@ -75,7 +76,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
 
         // reference data
         public ResourcePointerArray64<JointType> JointTypes;
-        public ResourceSimpleArray<RAGE_Vector4> p2data;
+        public SimpleArray<Vector4> p2data;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -131,7 +132,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
                 this.JointTypesPointer, // offset
                 this.JointTypesCount
             );
-            this.p2data = reader.ReadBlockAt<ResourceSimpleArray<RAGE_Vector4>>(
+            this.p2data = reader.ReadBlockAt<SimpleArray<Vector4>>(
                 this.p2, // offset
                 this.c1
             );

--- a/RageLib.GTA5/Resources/PC/Fragments/FragDrawable.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/FragDrawable.cs
@@ -25,6 +25,7 @@ using RageLib.Resources.GTA5.PC.Bounds;
 using RageLib.Resources.GTA5.PC.Drawables;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Fragments
 {
@@ -35,10 +36,10 @@ namespace RageLib.Resources.GTA5.PC.Fragments
 
         // structure data
         public ulong Unknown_A8h; // 0x0000000000000000
-        public RAGE_Matrix4x4 Unknown_B0h;      
+        public Matrix4x4 Unknown_B0h;      
         public ulong BoundPointer;
         public ResourceSimpleList64<ulong_r> Unknown_F8h_Data;
-        public ResourceSimpleList64<RAGE_Matrix4x4> Unknown_108h_Data;
+        public SimpleList64<Matrix4x4> Unknown_108h_Data;
         public ulong Unknown_118h; // 0x0000000000000000
         public ulong Unknown_120h; // 0x0000000000000000
         public ulong Unknown_128h; // 0x0000000000000000
@@ -60,10 +61,10 @@ namespace RageLib.Resources.GTA5.PC.Fragments
 
             // read structure data
             this.Unknown_A8h = reader.ReadUInt64();
-            this.Unknown_B0h = reader.ReadBlock<RAGE_Matrix4x4>();
+            this.Unknown_B0h = reader.ReadMatrix4x4();
             this.BoundPointer = reader.ReadUInt64();
             this.Unknown_F8h_Data = reader.ReadBlock<ResourceSimpleList64<ulong_r>>();
-            this.Unknown_108h_Data = reader.ReadBlock<ResourceSimpleList64<RAGE_Matrix4x4>>();
+            this.Unknown_108h_Data = reader.ReadBlock<SimpleList64<Matrix4x4>>();
             this.Unknown_118h = reader.ReadUInt64();
             this.Unknown_120h = reader.ReadUInt64();
             this.Unknown_128h = reader.ReadUInt64();
@@ -94,7 +95,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
 
             // write structure data
             writer.Write(this.Unknown_A8h);
-            writer.WriteBlock(this.Unknown_B0h);
+            writer.Write(this.Unknown_B0h);
             writer.Write(this.BoundPointer);
             writer.WriteBlock(this.Unknown_F8h_Data);
             writer.WriteBlock(this.Unknown_108h_Data);

--- a/RageLib.GTA5/Resources/PC/Fragments/FragDrawable.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/FragDrawable.cs
@@ -38,7 +38,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public ulong Unknown_A8h; // 0x0000000000000000
         public Matrix4x4 Unknown_B0h;      
         public ulong BoundPointer;
-        public ResourceSimpleList64<ulong_r> Unknown_F8h_Data;
+        public SimpleList64<ulong> Unknown_F8h_Data;
         public SimpleList64<Matrix4x4> Unknown_108h_Data;
         public ulong Unknown_118h; // 0x0000000000000000
         public ulong Unknown_120h; // 0x0000000000000000
@@ -63,7 +63,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.Unknown_A8h = reader.ReadUInt64();
             this.Unknown_B0h = reader.ReadMatrix4x4();
             this.BoundPointer = reader.ReadUInt64();
-            this.Unknown_F8h_Data = reader.ReadBlock<ResourceSimpleList64<ulong_r>>();
+            this.Unknown_F8h_Data = reader.ReadBlock<SimpleList64<ulong>>();
             this.Unknown_108h_Data = reader.ReadBlock<SimpleList64<Matrix4x4>>();
             this.Unknown_118h = reader.ReadUInt64();
             this.Unknown_120h = reader.ReadUInt64();

--- a/RageLib.GTA5/Resources/PC/Fragments/FragPhysicsLOD.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/FragPhysicsLOD.cs
@@ -23,6 +23,7 @@
 using RageLib.Resources.Common;
 using RageLib.Resources.GTA5.PC.Bounds;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Fragments
 {
@@ -39,15 +40,15 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public uint Unknown_1Ch;
         public ulong ArticulatedBodyTypePointer;
         public ulong Unknown_28h_Pointer;
-        public RAGE_Vector4 Unknown_30h;
-        public RAGE_Vector4 Unknown_40h;
-        public RAGE_Vector4 Unknown_50h; // unbrokenCGOffset ?
-        public RAGE_Vector4 DampingLinearC;
-        public RAGE_Vector4 DampingLinearV;
-        public RAGE_Vector4 DampingLinearV2;
-        public RAGE_Vector4 DampingAngularC;
-        public RAGE_Vector4 DampingAngularV;
-        public RAGE_Vector4 DampingAngularV2;
+        public Vector4 Unknown_30h;
+        public Vector4 Unknown_40h;
+        public Vector4 Unknown_50h; // unbrokenCGOffset ?
+        public Vector4 DampingLinearC;
+        public Vector4 DampingLinearV;
+        public Vector4 DampingLinearV2;
+        public Vector4 DampingAngularC;
+        public Vector4 DampingAngularV;
+        public Vector4 DampingAngularV2;
         public ulong GroupNamesPointer;
         public ulong GroupsPointer;
         public ulong ChildrenPointer;
@@ -79,8 +80,8 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public Archetype Archetype1;
         public Archetype Archetype2;
         public Bound Bound;
-        public ResourceSimpleArray<RAGE_Vector4> Unknown_F0h_Data;
-        public ResourceSimpleArray<RAGE_Vector4> Unknown_F8h_Data;
+        public SimpleArray<Vector4> Unknown_F0h_Data;
+        public SimpleArray<Vector4> Unknown_F8h_Data;
         public Unknown_F_001 Unknown_100h_Data;
         public ResourceSimpleArray<byte_r> Unknown_108h_Data;
         public ResourceSimpleArray<byte_r> Unknown_110h_Data;
@@ -99,15 +100,15 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.Unknown_1Ch = reader.ReadUInt32();
             this.ArticulatedBodyTypePointer = reader.ReadUInt64();
             this.Unknown_28h_Pointer = reader.ReadUInt64();
-            this.Unknown_30h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_40h = reader.ReadBlock<RAGE_Vector4>();
-            this.Unknown_50h = reader.ReadBlock<RAGE_Vector4>();
-            this.DampingLinearC = reader.ReadBlock<RAGE_Vector4>();
-            this.DampingLinearV = reader.ReadBlock<RAGE_Vector4>();
-            this.DampingLinearV2 = reader.ReadBlock<RAGE_Vector4>();
-            this.DampingAngularC = reader.ReadBlock<RAGE_Vector4>();
-            this.DampingAngularV = reader.ReadBlock<RAGE_Vector4>();
-            this.DampingAngularV2 = reader.ReadBlock<RAGE_Vector4>();
+            this.Unknown_30h = reader.ReadVector4();
+            this.Unknown_40h = reader.ReadVector4();
+            this.Unknown_50h = reader.ReadVector4();
+            this.DampingLinearC = reader.ReadVector4();
+            this.DampingLinearV = reader.ReadVector4();
+            this.DampingLinearV2 = reader.ReadVector4();
+            this.DampingAngularC = reader.ReadVector4();
+            this.DampingAngularV = reader.ReadVector4();
+            this.DampingAngularV2 = reader.ReadVector4();
             this.GroupNamesPointer = reader.ReadUInt64();
             this.GroupsPointer = reader.ReadUInt64();
             this.ChildrenPointer = reader.ReadUInt64();
@@ -159,11 +160,11 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.Bound = reader.ReadBlockAt<Bound>(
                 this.BoundPointer // offset
             );
-            this.Unknown_F0h_Data = reader.ReadBlockAt<ResourceSimpleArray<RAGE_Vector4>>(
+            this.Unknown_F0h_Data = reader.ReadBlockAt<SimpleArray<Vector4>>(
                 this.Unknown_F0h_Pointer, // offset
                 this.ChildrenCount
             );
-            this.Unknown_F8h_Data = reader.ReadBlockAt<ResourceSimpleArray<RAGE_Vector4>>(
+            this.Unknown_F8h_Data = reader.ReadBlockAt<SimpleArray<Vector4>>(
                 this.Unknown_F8h_Pointer, // offset
                 this.ChildrenCount
             );
@@ -213,15 +214,15 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             writer.Write(this.Unknown_1Ch);
             writer.Write(this.ArticulatedBodyTypePointer);
             writer.Write(this.Unknown_28h_Pointer);
-            writer.WriteBlock(this.Unknown_30h);
-            writer.WriteBlock(this.Unknown_40h);
-            writer.WriteBlock(this.Unknown_50h);
-            writer.WriteBlock(this.DampingLinearC);
-            writer.WriteBlock(this.DampingLinearV);
-            writer.WriteBlock(this.DampingLinearV2);
-            writer.WriteBlock(this.DampingAngularC);
-            writer.WriteBlock(this.DampingAngularV);
-            writer.WriteBlock(this.DampingAngularV2);
+            writer.Write(this.Unknown_30h);
+            writer.Write(this.Unknown_40h);
+            writer.Write(this.Unknown_50h);
+            writer.Write(this.DampingLinearC);
+            writer.Write(this.DampingLinearV);
+            writer.Write(this.DampingLinearV2);
+            writer.Write(this.DampingAngularC);
+            writer.Write(this.DampingAngularV);
+            writer.Write(this.DampingAngularV2);
             writer.Write(this.GroupNamesPointer);
             writer.Write(this.GroupsPointer);
             writer.Write(this.ChildrenPointer);

--- a/RageLib.GTA5/Resources/PC/Fragments/FragPhysicsLOD.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/FragPhysicsLOD.cs
@@ -73,7 +73,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
 
         // reference data
         public ArticulatedBodyType ArticulatedBodyType;
-        public ResourceSimpleArray<uint_r> Unknown_28h_Data;
+        public SimpleArray<uint> Unknown_28h_Data;
         public FragTypeGroupNames GroupNames;
         public ResourcePointerArray64<FragTypeGroup> Groups;
         public ResourcePointerArray64<FragTypeChild> Children;
@@ -83,8 +83,8 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public SimpleArray<Vector4> Unknown_F0h_Data;
         public SimpleArray<Vector4> Unknown_F8h_Data;
         public Unknown_F_001 Unknown_100h_Data;
-        public ResourceSimpleArray<byte_r> Unknown_108h_Data;
-        public ResourceSimpleArray<byte_r> Unknown_110h_Data;
+        public SimpleArray<byte> Unknown_108h_Data;
+        public SimpleArray<byte> Unknown_110h_Data;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -135,7 +135,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.ArticulatedBodyType = reader.ReadBlockAt<ArticulatedBodyType>(
                 this.ArticulatedBodyTypePointer // offset
             );
-            this.Unknown_28h_Data = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.Unknown_28h_Data = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.Unknown_28h_Pointer, // offset
                 this.ChildrenCount
             );
@@ -171,11 +171,11 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.Unknown_100h_Data = reader.ReadBlockAt<Unknown_F_001>(
                 this.Unknown_100h_Pointer // offset
             );
-            this.Unknown_108h_Data = reader.ReadBlockAt<ResourceSimpleArray<byte_r>>(
+            this.Unknown_108h_Data = reader.ReadBlockAt<SimpleArray<byte>>(
                 this.Unknown_108h_Pointer, // offset
                 this.Count1
             );
-            this.Unknown_110h_Data = reader.ReadBlockAt<ResourceSimpleArray<byte_r>>(
+            this.Unknown_110h_Data = reader.ReadBlockAt<SimpleArray<byte>>(
                 this.Unknown_110h_Pointer, // offset
                 this.Count2
             );

--- a/RageLib.GTA5/Resources/PC/Fragments/FragType.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/FragType.cs
@@ -25,6 +25,7 @@ using RageLib.Resources.GTA5.PC.Drawables;
 using System.Collections.Generic;
 using System;
 using RageLib.Resources.GTA5.PC.Clothes;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Fragments
 {
@@ -37,7 +38,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         // structure data
         public ulong Unknown_10h; // 0x0000000000000000
         public ulong Unknown_18h; // 0x0000000000000000
-        public RAGE_Vector3 BoundingSphereCenter;
+        public Vector3 BoundingSphereCenter;
         public float BoundingSphereRadius;
         public ulong DrawablePointer;
         public ulong Unknown_28h_Pointer;
@@ -100,7 +101,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             // read structure data
             this.Unknown_10h = reader.ReadUInt64();
             this.Unknown_18h = reader.ReadUInt64();
-            this.BoundingSphereCenter = reader.ReadBlock<RAGE_Vector3>();
+            this.BoundingSphereCenter = reader.ReadVector3();
             this.BoundingSphereRadius = reader.ReadSingle();
             this.DrawablePointer = reader.ReadUInt64();
             this.Unknown_28h_Pointer = reader.ReadUInt64();
@@ -196,7 +197,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             // write structure data
             writer.Write(this.Unknown_10h);
             writer.Write(this.Unknown_18h);
-            writer.WriteBlock(this.BoundingSphereCenter);
+            writer.Write(this.BoundingSphereCenter);
             writer.Write(this.BoundingSphereRadius);
             writer.Write(this.DrawablePointer);
             writer.Write(this.Unknown_28h_Pointer);

--- a/RageLib.GTA5/Resources/PC/Fragments/Unknown_F_001.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/Unknown_F_001.cs
@@ -22,6 +22,7 @@
 
 using RageLib.Resources.Common;
 using System;
+using System.Numerics;
 
 namespace RageLib.Resources.GTA5.PC.Fragments
 {
@@ -37,7 +38,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public uint Count;
         public uint Unknown_14h; // 0x00000000
         public ulong Unknown_18h; // 0x0000000000000000
-        public ResourceSimpleArray<RAGE_Matrix4x4> Data;
+        public SimpleArray<Matrix4x4> Data;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -50,7 +51,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.Count = reader.ReadUInt32();
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt64();
-            this.Data = reader.ReadBlock<ResourceSimpleArray<RAGE_Matrix4x4>>(
+            this.Data = reader.ReadBlock<SimpleArray<Matrix4x4>>(
               Count
               );
         }

--- a/RageLib.GTA5/Resources/PC/Fragments/Unknown_F_002.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/Unknown_F_002.cs
@@ -37,7 +37,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public uint Unknown_4h;
         public uint cnt1;
         public uint Unknown_Ch;
-        public ResourceSimpleArray<byte_r> Data;
+        public SimpleArray<byte> Data;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -49,7 +49,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.Unknown_4h = reader.ReadUInt32();
             this.cnt1 = reader.ReadUInt32();
             this.Unknown_Ch = reader.ReadUInt32();
-            this.Data = reader.ReadBlock<ResourceSimpleArray<byte_r>>(
+            this.Data = reader.ReadBlock<SimpleArray<byte>>(
               cnt1 - 16
               );
         }

--- a/RageLib.GTA5/Resources/PC/Fragments/Unknown_F_004.cs
+++ b/RageLib.GTA5/Resources/PC/Fragments/Unknown_F_004.cs
@@ -21,6 +21,7 @@
 */
 
 using System;
+using System.Numerics;
 using RageLib.Resources.Common;
 using RageLib.Resources.GTA5.PC.Drawables;
 
@@ -31,11 +32,11 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public override long BlockLength => 0x70;
 
         // structure data
-        public RAGE_Vector3 Unknown_0h;
+        public Vector3 Unknown_0h;
         public uint NaN_Ch; // 0x7F800001
-        public RAGE_Vector3 Unknown_10h;
+        public Vector3 Unknown_10h;
         public uint NaN_1Ch; // 0x7F800001
-        public RAGE_Vector3 Unknown_20h;
+        public Vector3 Unknown_20h;
         public uint NaN_2Ch; // 0x7F800001
         public float Unknown_30h;
         public float Unknown_34h;
@@ -47,7 +48,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public ushort Unknown_56h;
         public float Unknown_58h;
         public float Unknown_5Ch;
-        public RAGE_Vector3 Unknown_60h;
+        public Vector3 Unknown_60h;
         public uint NaN_6Ch; // 0x7F800001
 
         /// <summary>
@@ -56,11 +57,11 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public override void Read(ResourceDataReader reader, params object[] parameters)
         {
             // read structure data
-            this.Unknown_0h = reader.ReadBlock<RAGE_Vector3>();
+            this.Unknown_0h = reader.ReadVector3();
             this.NaN_Ch = reader.ReadUInt32();
-            this.Unknown_10h = reader.ReadBlock<RAGE_Vector3>();
+            this.Unknown_10h = reader.ReadVector3();
             this.NaN_1Ch = reader.ReadUInt32();
-            this.Unknown_20h = reader.ReadBlock<RAGE_Vector3>();
+            this.Unknown_20h = reader.ReadVector3();
             this.NaN_2Ch = reader.ReadUInt32();
             this.Unknown_30h = reader.ReadSingle();
             this.Unknown_34h = reader.ReadSingle();
@@ -72,7 +73,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             this.Unknown_56h = reader.ReadUInt16();
             this.Unknown_58h = reader.ReadSingle();
             this.Unknown_5Ch = reader.ReadSingle();
-            this.Unknown_60h = reader.ReadBlock<RAGE_Vector3>();
+            this.Unknown_60h = reader.ReadVector3();
             this.NaN_6Ch = reader.ReadUInt32();
         }
 
@@ -82,11 +83,11 @@ namespace RageLib.Resources.GTA5.PC.Fragments
         public override void Write(ResourceDataWriter writer, params object[] parameters)
         {
             // write structure data
-            writer.WriteBlock(this.Unknown_0h);
+            writer.Write(this.Unknown_0h);
             writer.Write(this.NaN_Ch);
-            writer.WriteBlock(this.Unknown_10h);
+            writer.Write(this.Unknown_10h);
             writer.Write(this.NaN_1Ch);
-            writer.WriteBlock(this.Unknown_20h);
+            writer.Write(this.Unknown_20h);
             writer.Write(this.NaN_2Ch);
             writer.Write(this.Unknown_30h);
             writer.Write(this.Unknown_34h);
@@ -98,7 +99,7 @@ namespace RageLib.Resources.GTA5.PC.Fragments
             writer.Write(this.Unknown_56h);
             writer.Write(this.Unknown_58h);
             writer.Write(this.Unknown_5Ch);
-            writer.WriteBlock(this.Unknown_60h);
+            writer.Write(this.Unknown_60h);
             writer.Write(this.NaN_6Ch);
         }
 

--- a/RageLib.GTA5/Resources/PC/Meta/DataBlock.cs
+++ b/RageLib.GTA5/Resources/PC/Meta/DataBlock.cs
@@ -35,7 +35,7 @@ namespace RageLib.Resources.GTA5.PC.Meta
         public long DataPointer { get; private set; }
 
         // reference data
-        public ResourceSimpleArray<byte_r> Data { get; set; }
+        public SimpleArray<byte> Data { get; set; }
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -48,7 +48,7 @@ namespace RageLib.Resources.GTA5.PC.Meta
             this.DataPointer = reader.ReadInt64();
 
             // read reference data
-            this.Data = reader.ReadBlockAt<ResourceSimpleArray<byte_r>>(
+            this.Data = reader.ReadBlockAt<SimpleArray<byte>>(
                 (ulong)this.DataPointer, // offset
                 this.DataLength
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/AdjPolysList.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/AdjPolysList.cs
@@ -44,7 +44,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
 
         // reference data
         public ResourceSimpleArray<AdjPolysListPart> ListParts;
-        public ResourceSimpleArray<uint_r> ListOffsets;
+        public SimpleArray<uint> ListOffsets;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -68,7 +68,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
                 this.ListPartsPointer, // offset
                 this.ListPartsCount
             );
-            this.ListOffsets = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.ListOffsets = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.ListOffsetsPointer, // offset
                 this.ListPartsCount
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/IndicesList.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/IndicesList.cs
@@ -44,7 +44,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
 
         // reference data
         public ResourceSimpleArray<IndicesListPart> ListParts;
-        public ResourceSimpleArray<uint_r> ListOffsets;
+        public SimpleArray<uint> ListOffsets;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -68,7 +68,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
                 this.ListPartsPointer, // offset
                 this.ListPartsCount
             );
-            this.ListOffsets = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.ListOffsets = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.ListOffsetsPointer, // offset
                 this.ListPartsCount
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/IndicesListPart.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/IndicesListPart.cs
@@ -35,7 +35,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
         public uint Unknown_Ch; // 0x00000000
 
         // reference data
-        public ResourceSimpleArray<ushort_r> Indices;
+        public SimpleArray<ushort> Indices;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -48,7 +48,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
             this.Unknown_Ch = reader.ReadUInt32();
 
             // read reference data
-            this.Indices = reader.ReadBlockAt<ResourceSimpleArray<ushort_r>>(
+            this.Indices = reader.ReadBlockAt<SimpleArray<ushort>>(
                 this.IndicesPointer, // offset
                 this.IndicesCount
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/Navigation.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/Navigation.cs
@@ -120,7 +120,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
         public PolysList Polys;
         public Sector SectorTree;
         public ResourceSimpleArray<Portal> Portals;
-        public ResourceSimpleArray<ushort_r> p8data;
+        public SimpleArray<ushort> p8data;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -232,7 +232,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
                 this.PortalsPointer, // offset
                 this.PortalsCount
             );
-            this.p8data = reader.ReadBlockAt<ResourceSimpleArray<ushort_r>>(
+            this.p8data = reader.ReadBlockAt<SimpleArray<ushort>>(
                 this.p8, // offset
                 this.c1
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/PolysList.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/PolysList.cs
@@ -44,7 +44,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
 
         // reference data
         public ResourceSimpleArray<PolysListPart> ListParts;
-        public ResourceSimpleArray<uint_r> ListOffsets;
+        public SimpleArray<uint> ListOffsets;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -68,7 +68,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
                 this.ListPartsPointer, // offset
                 this.ListPartsCount
             );
-            this.ListOffsets = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.ListOffsets = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.ListOffsetsPointer, // offset
                 this.ListPartsCount
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/SectorData.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/SectorData.cs
@@ -39,7 +39,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
         public uint Unknown_1Ch; // 0x00000000
 
         // reference data
-        public ResourceSimpleArray<ushort_r> p1data;
+        public SimpleArray<ushort> p1data;
         public ResourceSimpleArray<SectorDataUnk> p2data;
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
             this.Unknown_1Ch = reader.ReadUInt32();
 
             // read reference data
-            this.p1data = reader.ReadBlockAt<ResourceSimpleArray<ushort_r>>(
+            this.p1data = reader.ReadBlockAt<SimpleArray<ushort>>(
                 this.p1, // offset
                 this.c2
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/VerticesList.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/VerticesList.cs
@@ -44,7 +44,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
 
         // reference data
         public ResourceSimpleArray<VerticesListPart> ListParts;
-        public ResourceSimpleArray<uint_r> ListOffsets;
+        public SimpleArray<uint> ListOffsets;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -68,7 +68,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
                 this.ListPartsPointer, // offset
                 this.ListPartsCount
             );
-            this.ListOffsets = reader.ReadBlockAt<ResourceSimpleArray<uint_r>>(
+            this.ListOffsets = reader.ReadBlockAt<SimpleArray<uint>>(
                 this.ListOffsetsPointer, // offset
                 this.ListPartsCount
             );

--- a/RageLib.GTA5/Resources/PC/Nodes/NodesFile.cs
+++ b/RageLib.GTA5/Resources/PC/Nodes/NodesFile.cs
@@ -55,7 +55,7 @@ namespace RageLib.Resources.GTA5.PC.Nodes
         public ResourceSimpleArray<Node> Nodes;
         public ResourceSimpleArray<Unknown_ND_002> Unknown_28h_Data;
         public ResourceSimpleArray<Unknown_ND_003> Unknown_38h_Data;
-        public ResourceSimpleArray<byte_r> Unknown_40h_Data;
+        public SimpleArray<byte> Unknown_40h_Data;
         public ResourceSimpleArray<Unknown_ND_004> Unknown_50h_Data;
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace RageLib.Resources.GTA5.PC.Nodes
                 this.Unknown_38h_Pointer, // offset
                 this.len4
             );
-            this.Unknown_40h_Data = reader.ReadBlockAt<ResourceSimpleArray<byte_r>>(
+            this.Unknown_40h_Data = reader.ReadBlockAt<SimpleArray<byte>>(
                 this.Unknown_40h_Pointer, // offset
                 this.len5
             );

--- a/RageLib.GTA5/Resources/PC/Particles/Unknown_P_013.cs
+++ b/RageLib.GTA5/Resources/PC/Particles/Unknown_P_013.cs
@@ -46,7 +46,7 @@ namespace RageLib.Resources.GTA5.PC.Particles
         public uint Unknown_34h; // 0x00000000
         public uint Unknown_38h; // 0x00000000
         public uint Unknown_3Ch; // 0x00000000
-        public ResourceSimpleList64<uint_r> Unknown_40h;
+        public SimpleList64<uint> Unknown_40h;
         public uint Unknown_50h;
         public uint Unknown_54h; // 0x00000000
 
@@ -72,7 +72,7 @@ namespace RageLib.Resources.GTA5.PC.Particles
             this.Unknown_34h = reader.ReadUInt32();
             this.Unknown_38h = reader.ReadUInt32();
             this.Unknown_3Ch = reader.ReadUInt32();
-            this.Unknown_40h = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Unknown_40h = reader.ReadBlock<SimpleList64<uint>>();
             this.Unknown_50h = reader.ReadUInt32();
             this.Unknown_54h = reader.ReadUInt32();
         }

--- a/RageLib.GTA5/Resources/PC/Textures/TextureDictionary.cs
+++ b/RageLib.GTA5/Resources/PC/Textures/TextureDictionary.cs
@@ -36,12 +36,12 @@ namespace RageLib.Resources.GTA5.PC.Textures
         public uint Unknown_14h; // 0x00000000
         public uint Unknown_18h; // 0x00000001
         public uint Unknown_1Ch; // 0x00000000
-        public ResourceSimpleList64<uint_r> TextureNameHashes;
+        public SimpleList64<uint> TextureNameHashes;
         public ResourcePointerList64<TextureDX11> Textures;
 
         public TextureDictionary()
         {
-            this.TextureNameHashes = new ResourceSimpleList64<uint_r>();
+            this.TextureNameHashes = new SimpleList64<uint>();
             this.Textures = new ResourcePointerList64<TextureDX11>();
         }
 
@@ -57,7 +57,7 @@ namespace RageLib.Resources.GTA5.PC.Textures
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.TextureNameHashes = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.TextureNameHashes = reader.ReadBlock<SimpleList64<uint>>();
             this.Textures = reader.ReadBlock<ResourcePointerList64<TextureDX11>>();
         }
 

--- a/RageLib.RDR2/Resources/PC/Drawables/IndexBuffer.cs
+++ b/RageLib.RDR2/Resources/PC/Drawables/IndexBuffer.cs
@@ -26,7 +26,7 @@ namespace RageLib.Resources.RDR2.PC.Drawables
         public ulong Unknown_38h;           // 0x0000000000000000
 
         // reference data
-        public ResourceSimpleArray<ushort_r> Indices;
+        public SimpleArray<ushort> Indices;
         public Struct_15 Unknown_30h_Data;
 
 

--- a/RageLib/Data/DataReader.cs
+++ b/RageLib/Data/DataReader.cs
@@ -277,7 +277,7 @@ namespace RageLib.Data
             return m;
         }
 
-        public T[] ReadUnmanaged<T>(int count) where T : unmanaged
+        public T[] ReadArray<T>(int count) where T : unmanaged
         {
             int sizeOf = Unsafe.SizeOf<T>();
 

--- a/RageLib/Data/DataWriter.cs
+++ b/RageLib/Data/DataWriter.cs
@@ -259,7 +259,7 @@ namespace RageLib.Data
             Write(value.M44);
         }
 
-        public void WriteUnmanaged<T>(T[] items) where T : unmanaged
+        public void WriteArray<T>(T[] items) where T : unmanaged
         {
             if (items == null) 
                 return;

--- a/RageLib/Resources/Common/AtHashMap.cs
+++ b/RageLib/Resources/Common/AtHashMap.cs
@@ -56,9 +56,7 @@ namespace RageLib.Resources.Common
         /// </summary>
         public override IResourceBlock[] GetReferences()
         {
-            var list = new List<IResourceBlock>();
-            if (Buckets != null) list.Add(Buckets);
-            return list.ToArray();
+            return Buckets == null ? Array.Empty<IResourceBlock>() : new IResourceBlock[] { Buckets };
         }
 
         // Don't use it for now
@@ -217,9 +215,7 @@ namespace RageLib.Resources.Common
         /// </summary>
         public override IResourceBlock[] GetReferences()
         {
-            var list = new List<IResourceBlock>();
-            if (Next != null) list.Add(Next);
-            return list.ToArray();
+            return Next == null ? Array.Empty<IResourceBlock>() : new IResourceBlock[] { Next };
         }
 
         public override Tuple<long, IResourceBlock>[] GetParts()

--- a/RageLib/Resources/Common/PgDictionary64.cs
+++ b/RageLib/Resources/Common/PgDictionary64.cs
@@ -14,7 +14,7 @@ namespace RageLib.Resources.Common
         public ulong ParentPointer; // 0x0000000000000000
         public uint Count; // 0x00000001
         public uint Unknown_1Ch; // 0x00000000
-        public ResourceSimpleList64<uint_r> Hashes;
+        public SimpleList64<uint> Hashes;
         public ResourcePointerList64<T> Values;
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace RageLib.Resources.Common
             this.ParentPointer = reader.ReadUInt64();
             this.Count = reader.ReadUInt32();
             this.Unknown_1Ch = reader.ReadUInt32();
-            this.Hashes = reader.ReadBlock<ResourceSimpleList64<uint_r>>();
+            this.Hashes = reader.ReadBlock<SimpleList64<uint>>();
             this.Values = reader.ReadBlock<ResourcePointerList64<T>>();
         }
 

--- a/RageLib/Resources/Common/ResourcePointerList.cs
+++ b/RageLib/Resources/Common/ResourcePointerList.cs
@@ -20,6 +20,8 @@
     THE SOFTWARE.
 */
 
+using System;
+
 namespace RageLib.Resources.Common
 {
     public class ResourcePointerList<T> : ResourceSystemBlock where T : IResourceSystemBlock, new()
@@ -35,7 +37,7 @@ namespace RageLib.Resources.Common
         public ushort DataCount2;
 
         // reference data
-        public ResourcePointerArray<T> data_items;
+        public ResourcePointerArray<T> Entries;
         
         public override void Read(ResourceDataReader reader, params object[] parameters)
         {
@@ -43,7 +45,7 @@ namespace RageLib.Resources.Common
             this.DataCount1 = reader.ReadUInt16();
             this.DataCount2 = reader.ReadUInt16();
 
-            this.data_items = reader.ReadBlockAt<ResourcePointerArray<T>>(
+            this.Entries = reader.ReadBlockAt<ResourcePointerArray<T>>(
                 this.DataPointer, // offset
                 this.DataCount1
             );
@@ -52,14 +54,19 @@ namespace RageLib.Resources.Common
         public override void Write(ResourceDataWriter writer, params object[] parameters)
         {
             // update...
-            this.DataPointer = (uint)data_items.BlockPosition;
-            this.DataCount1 = (ushort)data_items.Count;
-            this.DataCount2 = (ushort)data_items.Count;
+            this.DataPointer = (uint)Entries.BlockPosition;
+            this.DataCount1 = (ushort)Entries.Count;
+            this.DataCount2 = (ushort)Entries.Count;
 
             // write...
             writer.Write(DataPointer);
             writer.Write(DataCount1);
             writer.Write(DataCount2);
+        }
+
+        public override IResourceBlock[] GetReferences()
+        {
+            return Entries == null ? Array.Empty<IResourceBlock>() : new IResourceBlock[] { Entries };
         }
     }
 }

--- a/RageLib/Resources/Common/ResourcePointerList64.cs
+++ b/RageLib/Resources/Common/ResourcePointerList64.cs
@@ -20,6 +20,7 @@
     THE SOFTWARE.
 */
 
+using System;
 using System.Collections.Generic;
 
 namespace RageLib.Resources.Common
@@ -68,9 +69,7 @@ namespace RageLib.Resources.Common
 
         public override IResourceBlock[] GetReferences()
         {
-            var list = new List<IResourceBlock>();
-            if (Entries != null) list.Add(Entries);
-            return list.ToArray();
+            return Entries == null ? Array.Empty<IResourceBlock>() : new IResourceBlock[] { Entries };
         }
     }
 }

--- a/RageLib/Resources/Common/ResourceSimpleArrayArray64.cs
+++ b/RageLib/Resources/Common/ResourceSimpleArrayArray64.cs
@@ -63,7 +63,7 @@ namespace RageLib.Resources.Common
         public override void Read(ResourceDataReader reader, params object[] parameters)
         {
 
-            var numEl = (ResourceSimpleArray<uint_r>)parameters[1];
+            var numEl = (SimpleArray<uint>)parameters[1];
 
             ptr_list = new List<ulong>(numEl.Count);
             for (int i = 0; i < numEl.Count; i++)

--- a/RageLib/Resources/Common/ResourceSimpleList32_64.cs
+++ b/RageLib/Resources/Common/ResourceSimpleList32_64.cs
@@ -20,6 +20,7 @@
     THE SOFTWARE.
 */
 
+using System;
 using System.Collections.Generic;
 
 namespace RageLib.Resources.Common
@@ -78,9 +79,7 @@ namespace RageLib.Resources.Common
         /// </summary>
         public override IResourceBlock[] GetReferences()
         {
-            var list = new List<IResourceBlock>();
-            if (Entries != null) list.Add(Entries);
-            return list.ToArray();
+            return Entries == null ? Array.Empty<IResourceBlock>() : new IResourceBlock[] { Entries };
         }
     }
 }

--- a/RageLib/Resources/Common/ResourceSimpleList64.cs
+++ b/RageLib/Resources/Common/ResourceSimpleList64.cs
@@ -20,6 +20,7 @@
     THE SOFTWARE.
 */
 
+using System;
 using System.Collections.Generic;
 
 namespace RageLib.Resources.Common
@@ -79,9 +80,7 @@ namespace RageLib.Resources.Common
         /// </summary>
         public override IResourceBlock[] GetReferences()
         {
-            var list = new List<IResourceBlock>();
-            if (Entries != null) list.Add(Entries);
-            return list.ToArray();
+            return Entries == null ? Array.Empty<IResourceBlock>() : new IResourceBlock[] { Entries };
         }
     }
 }

--- a/RageLib/Resources/Common/SimpleArray.cs
+++ b/RageLib/Resources/Common/SimpleArray.cs
@@ -6,21 +6,26 @@ using System.Runtime.CompilerServices;
 namespace RageLib.Resources.Common
 {
     /// <summary>
-    /// Represents an array of type T.
+    /// A <see cref="ResourceSystemBlock"/> which holds an array of unmanaged type.
     /// </summary>
-    public class SimpleArray<T> : ResourceSystemBlock, IList<T> where T : unmanaged
+    public class SimpleArray<T> : ResourceSystemBlock, IEnumerable where T : unmanaged
     {
         /// <summary>
         /// Gets the length of the data block.
         /// </summary>
-        public override long BlockLength => Data != null ? Data.Count * Unsafe.SizeOf<T>() : 0;
+        public override long BlockLength => Data.Length * Unsafe.SizeOf<T>();
 
         // structure data
-        private List<T> Data;
+        private T[] Data;
 
         public SimpleArray()
         {
-            Data = new List<T>();
+            Data = Array.Empty<T>();
+        }
+
+        public SimpleArray(T[] array)
+        {
+            Data = array;
         }
 
         /// <summary>
@@ -30,8 +35,7 @@ namespace RageLib.Resources.Common
         {
             int count = Convert.ToInt32(parameters[0]);
 
-            Data.Capacity += count;
-            Data.AddRange(reader.ReadArray<T>(count));
+            Data = reader.ReadArray<T>(count);
         }
 
         /// <summary>
@@ -39,12 +43,15 @@ namespace RageLib.Resources.Common
         /// </summary>
         public override void Write(ResourceDataWriter writer, params object[] parameters)
         {
-            writer.WriteArray<T>(Data.ToArray());
+            writer.WriteArray<T>(Data);
         }
 
-        public int Count => Data.Count;
+        public IEnumerator GetEnumerator()
+        {
+            return Data.GetEnumerator();
+        }
 
-        public bool IsReadOnly => false;
+        public int Count => Data.Length;
 
         public T this[int index] 
         { 
@@ -52,54 +59,10 @@ namespace RageLib.Resources.Common
             set => Data[index] = value;
         }
 
-        public int IndexOf(T item)
+        // TODO: Check usage to know if it's safe to return without creating a copy
+        public T[] ToArray()
         {
-            return Data.IndexOf(item);
-        }
-
-        public void Insert(int index, T item)
-        {
-            Data.Insert(index, item);
-        }
-
-        public void RemoveAt(int index)
-        {
-            Data.RemoveAt(index);
-        }
-
-        public void Add(T item)
-        {
-            Data.Add(item);
-        }
-
-        public void Clear()
-        {
-            Data.Clear();
-        }
-
-        public bool Contains(T item)
-        {
-            return Data.Contains(item);
-        }
-
-        public void CopyTo(T[] array, int arrayIndex)
-        {
-            Data.CopyTo(array, arrayIndex);
-        }
-
-        public bool Remove(T item)
-        {
-            return Data.Remove(item);
-        }
-
-        public IEnumerator<T> GetEnumerator()
-        {
-            return Data.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return Data.GetEnumerator();
+            return (T[])Data.Clone();
         }
     }
 }

--- a/RageLib/Resources/Common/SimpleArray.cs
+++ b/RageLib/Resources/Common/SimpleArray.cs
@@ -31,7 +31,7 @@ namespace RageLib.Resources.Common
             int count = Convert.ToInt32(parameters[0]);
 
             Data.Capacity += count;
-            Data.AddRange(reader.ReadUnmanaged<T>(count));
+            Data.AddRange(reader.ReadArray<T>(count));
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace RageLib.Resources.Common
         /// </summary>
         public override void Write(ResourceDataWriter writer, params object[] parameters)
         {
-            writer.WriteUnmanaged<T>(Data.ToArray());
+            writer.WriteArray<T>(Data.ToArray());
         }
 
         public int Count => Data.Count;

--- a/RageLib/Resources/Common/SimpleList64.cs
+++ b/RageLib/Resources/Common/SimpleList64.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace RageLib.Resources.Common
 {
@@ -57,9 +58,7 @@ namespace RageLib.Resources.Common
         /// </summary>
         public override IResourceBlock[] GetReferences()
         {
-            var list = new List<IResourceBlock>();
-            if (Entries != null) list.Add(Entries);
-            return list.ToArray();
+            return Entries == null ? Array.Empty<IResourceBlock>() : new IResourceBlock[] { Entries };
         }
     }
 }

--- a/RageLib/Resources/PgBase64.cs
+++ b/RageLib/Resources/PgBase64.cs
@@ -20,6 +20,7 @@
     THE SOFTWARE.
 */
 
+using System;
 using System.Collections.Generic;
 
 namespace RageLib.Resources
@@ -70,9 +71,7 @@ namespace RageLib.Resources
         /// </summary>
         public override IResourceBlock[] GetReferences()
         {
-            var list = new List<IResourceBlock>();
-            if (PagesInfo != null) list.Add(PagesInfo);
-            return list.ToArray();
+            return PagesInfo == null ? Array.Empty<IResourceBlock>() : new IResourceBlock[] { PagesInfo };
         }
     }
 }

--- a/RageLib/Resources/ResourceBlock.cs
+++ b/RageLib/Resources/ResourceBlock.cs
@@ -78,7 +78,7 @@ namespace RageLib.Resources
         /// </summary>
         public virtual Tuple<long, IResourceBlock>[] GetParts()
         {
-            return new Tuple<long, IResourceBlock>[0];
+            return Array.Empty<Tuple<long, IResourceBlock>>();
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace RageLib.Resources
         /// </summary>
         public virtual IResourceBlock[] GetReferences()
         {
-            return new IResourceBlock[0];
+            return Array.Empty<IResourceBlock>();
         }
     }
 


### PR DESCRIPTION
- https://github.com/carmineos/gta-toolkit/commit/1e3132eac8fa2ebe40d755594248a9e4d360d91e Avoid using wrappers of unmanaged types for structure data
- https://github.com/carmineos/gta-toolkit/commit/e2a9c194bb9839483712ab267a09c8d5348986b4 and https://github.com/carmineos/gta-toolkit/commit/0181f04839963e1a1e180fd9e2e7884991ead92f update SimpleArray and use it where data is unmanaged type
- https://github.com/carmineos/gta-toolkit/commit/552ae5861d35521499794af35f8b9355f2b16c5e and https://github.com/carmineos/gta-toolkit/commit/6f8bda7a5b5653916db0ec51c0b0179b506db6b0 avoid useless heap allocations in GetReferences and GetParts for IResourceBlock and common blocks