### PR TITLE
Replace small resource blocks with structs

### DIFF
--- a/RageLib.GTA5/Resources/PC/Bounds/BVH.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BVH.cs
@@ -32,7 +32,7 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public override long BlockLength => 0x80;
 
         // structure data
-        public ResourceSimpleList32_64<BVHNode> Nodes;
+        public SimpleList64_32<BVHNode> Nodes;
         public uint Unknown_10h; // 0x00000000
         public uint Unknown_14h; // 0x00000000
         public uint Unknown_18h; // 0x00000000
@@ -42,7 +42,7 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public Vector4 BoundingBoxCenter;
         public Vector4 QuantumInverse;
         public Vector4 Quantum; // bounding box dimension / 2^16
-        public ResourceSimpleList64<BVHTreeInfo> Trees;
+        public SimpleList64<BVHTreeInfo> Trees;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -50,7 +50,7 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public override void Read(ResourceDataReader reader, params object[] parameters)
         {
             // read structure data
-            this.Nodes = reader.ReadBlock<ResourceSimpleList32_64<BVHNode>>();
+            this.Nodes = reader.ReadBlock<SimpleList64_32<BVHNode>>();
             this.Unknown_10h = reader.ReadUInt32();
             this.Unknown_14h = reader.ReadUInt32();
             this.Unknown_18h = reader.ReadUInt32();
@@ -60,7 +60,7 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             this.BoundingBoxCenter = reader.ReadVector4();
             this.QuantumInverse = reader.ReadVector4();
             this.Quantum = reader.ReadVector4();
-            this.Trees = reader.ReadBlock<ResourceSimpleList64<BVHTreeInfo>>();
+            this.Trees = reader.ReadBlock<SimpleList64<BVHTreeInfo>>();
         }
 
         /// <summary>

--- a/RageLib.GTA5/Resources/PC/Bounds/BVHNode.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BVHNode.cs
@@ -20,52 +20,35 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Bounds
 {
-    public class BVHNode : ResourceSystemBlock
+    public struct BVHNode : IResourceStruct<BVHNode>
     {
-        public override long BlockLength => 0x10;
+        public short MinX;
+        public short MinY;
+        public short MinZ;
+        public short MaxX;
+        public short MaxY;
+        public short MaxZ;
+        public short NodeId;
+        public short ChildrenCount;
 
-        // structure data
-        public ushort MinX;
-        public ushort MinY;
-        public ushort MinZ;
-        public ushort MaxX;
-        public ushort MaxY;
-        public ushort MaxZ;
-        public ushort Unknown_Ch;
-        public ushort Unknown_Eh;
-
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public BVHNode ReverseEndianness()
         {
-            // read structure data
-            this.MinX = reader.ReadUInt16();
-            this.MinY = reader.ReadUInt16();
-            this.MinZ = reader.ReadUInt16();
-            this.MaxX = reader.ReadUInt16();
-            this.MaxY = reader.ReadUInt16();
-            this.MaxZ = reader.ReadUInt16();
-            this.Unknown_Ch = reader.ReadUInt16();
-            this.Unknown_Eh = reader.ReadUInt16();
-        }
+            return new BVHNode()
+            {
 
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.MinX);
-            writer.Write(this.MinY);
-            writer.Write(this.MinZ);
-            writer.Write(this.MaxX);
-            writer.Write(this.MaxY);
-            writer.Write(this.MaxZ);
-            writer.Write(this.Unknown_Ch);
-            writer.Write(this.Unknown_Eh);
+                MinX = EndiannessExtensions.ReverseEndianness(MinX),
+                MinY = EndiannessExtensions.ReverseEndianness(MinY),
+                MinZ = EndiannessExtensions.ReverseEndianness(MinZ),
+                MaxX = EndiannessExtensions.ReverseEndianness(MaxX),
+                MaxY = EndiannessExtensions.ReverseEndianness(MaxY),
+                MaxZ = EndiannessExtensions.ReverseEndianness(MaxZ),
+                NodeId = EndiannessExtensions.ReverseEndianness(NodeId),
+                ChildrenCount = EndiannessExtensions.ReverseEndianness(ChildrenCount),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Bounds/BVHTreeInfo.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BVHTreeInfo.cs
@@ -20,52 +20,34 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Bounds
 {
-    public class BVHTreeInfo : ResourceSystemBlock
+    public struct BVHTreeInfo : IResourceStruct<BVHTreeInfo>
     {
-        public override long BlockLength => 0x10;
+        public short MinX;
+        public short MinY;
+        public short MinZ;
+        public short MaxX;
+        public short MaxY;
+        public short MaxZ;
+        public short NodeIndex1;
+        public short NodeIndex2;
 
-        // structure data
-        public ushort MinX;
-        public ushort MinY;
-        public ushort MinZ;
-        public ushort MaxX;
-        public ushort MaxY;
-        public ushort MaxZ;
-        public ushort NodeIndex1;
-        public ushort NodeIndex2;
-
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public BVHTreeInfo ReverseEndianness()
         {
-            // read structure data
-            this.MinX = reader.ReadUInt16();
-            this.MinY = reader.ReadUInt16();
-            this.MinZ = reader.ReadUInt16();
-            this.MaxX = reader.ReadUInt16();
-            this.MaxY = reader.ReadUInt16();
-            this.MaxZ = reader.ReadUInt16();
-            this.NodeIndex1 = reader.ReadUInt16();
-            this.NodeIndex2 = reader.ReadUInt16();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.MinX);
-            writer.Write(this.MinY);
-            writer.Write(this.MinZ);
-            writer.Write(this.MaxX);
-            writer.Write(this.MaxY);
-            writer.Write(this.MaxZ);
-            writer.Write(this.NodeIndex1);
-            writer.Write(this.NodeIndex2);
+            return new BVHTreeInfo()
+            {
+                MinX = EndiannessExtensions.ReverseEndianness(MinX),
+                MinY = EndiannessExtensions.ReverseEndianness(MinY),
+                MinZ = EndiannessExtensions.ReverseEndianness(MinZ),
+                MaxX = EndiannessExtensions.ReverseEndianness(MaxX),
+                MaxY = EndiannessExtensions.ReverseEndianness(MaxY),
+                MaxZ = EndiannessExtensions.ReverseEndianness(MaxZ),
+                NodeIndex1 = EndiannessExtensions.ReverseEndianness(NodeIndex1),
+                NodeIndex2 = EndiannessExtensions.ReverseEndianness(NodeIndex2),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundGeometry.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundGeometry.cs
@@ -49,7 +49,7 @@ namespace RageLib.Resources.GTA5.PC.Bounds
         public uint Unknown_12Ch; // 0x00000000
 
         // reference data
-        public ResourceSimpleArray<BoundMaterial> Materials;
+        public SimpleArray<BoundMaterial> Materials;
         public SimpleArray<uint> MaterialColours;
         public SimpleArray<byte> PolygonMaterialIndices;
 
@@ -78,7 +78,7 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             this.Unknown_12Ch = reader.ReadUInt32();
 
             // read reference data
-            this.Materials = reader.ReadBlockAt<ResourceSimpleArray<BoundMaterial>>(
+            this.Materials = reader.ReadBlockAt<SimpleArray<BoundMaterial>>(
                 this.MaterialsPointer, // offset
                 this.MaterialsCount
             );

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundMaterial.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundMaterial.cs
@@ -20,14 +20,13 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
 using System;
 
 namespace RageLib.Resources.GTA5.PC.Bounds
 {
-    public class BoundMaterial : ResourceSystemBlock
+    public struct BoundMaterial : IResourceStruct<BoundMaterial>
     {
-        public override long BlockLength => 8;
-
         // structure data
         public ulong Data;
 
@@ -73,22 +72,12 @@ namespace RageLib.Resources.GTA5.PC.Bounds
             set => Data &= 0x0000FFFFFFFFFFFFu | ((ulong)value << 48);
         }
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public BoundMaterial ReverseEndianness()
         {
-            // read structure data
-            this.Data = reader.ReadUInt64();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Data);
+            return new BoundMaterial()
+            {
+                Data = EndiannessExtensions.ReverseEndianness(Data)
+            };
         }
     }
 

--- a/RageLib.GTA5/Resources/PC/Bounds/BoundVertex.cs
+++ b/RageLib.GTA5/Resources/PC/Bounds/BoundVertex.cs
@@ -20,37 +20,24 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Bounds
 {
-    public class BoundVertex : ResourceSystemBlock
+    public struct BoundVertex : IResourceStruct<BoundVertex>
     {
-        public override long BlockLength => 6;
-
-        // structure data
         public short X;
         public short Y;
         public short Z;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public BoundVertex ReverseEndianness()
         {
-            // read structure data
-            this.X = reader.ReadInt16();
-            this.Y = reader.ReadInt16();
-            this.Z = reader.ReadInt16();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.X);
-            writer.Write(this.Y);
-            writer.Write(this.Z);
+            return new BoundVertex()
+            {
+                X = EndiannessExtensions.ReverseEndianness(X),
+                Y = EndiannessExtensions.ReverseEndianness(Y),
+                Z = EndiannessExtensions.ReverseEndianness(Z),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Navigations/AdjPoly.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/AdjPoly.cs
@@ -20,35 +20,24 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Navigations
 {
     // TAdjPoly
-    public class AdjPoly : ResourceSystemBlock
+    public struct AdjPoly : IResourceStruct<AdjPoly>
     {
-        public override long BlockLength => 8;
-
         // structure data
         public uint Unknown_0h;
         public uint Unknown_4h;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public AdjPoly ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt32();
-            this.Unknown_4h = reader.ReadUInt32();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_4h);
+            return new AdjPoly()
+            {
+                Unknown_0h = EndiannessExtensions.ReverseEndianness(Unknown_0h),
+                Unknown_4h = EndiannessExtensions.ReverseEndianness(Unknown_4h),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Navigations/CompressedVertex.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/CompressedVertex.cs
@@ -20,38 +20,26 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Navigations
 {
     // CNavMeshCompressedVertex
-    public class CompressedVertex : ResourceSystemBlock
+    public struct CompressedVertex : IResourceStruct<CompressedVertex>
     {
-        public override long BlockLength => 6;
-
         // structure data
-        public ushort Unknown_0h;
-        public ushort Unknown_2h;
-        public ushort Unknown_4h;
+        public short X;
+        public short Y;
+        public short Z;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public CompressedVertex ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt16();
-            this.Unknown_2h = reader.ReadUInt16();
-            this.Unknown_4h = reader.ReadUInt16();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_2h);
-            writer.Write(this.Unknown_4h);
+            return new CompressedVertex()
+            {
+                X = EndiannessExtensions.ReverseEndianness(X),
+                Y = EndiannessExtensions.ReverseEndianness(Y),
+                Z = EndiannessExtensions.ReverseEndianness(Z),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Navigations/Navigation.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/Navigation.cs
@@ -97,12 +97,12 @@ namespace RageLib.Resources.GTA5.PC.Navigations
         public uint Unknown_16Ch; // 0x00000000
 
         // reference data
-        public ResourceSplitArray<CompressedVertex> Vertices;
-        public ResourceSplitArray<ushort_r> Indices;
-        public ResourceSplitArray<AdjPoly> AdjPolys;
-        public ResourceSplitArray<Poly> Polys;
+        public SimpleSplitArray<CompressedVertex> Vertices;
+        public SimpleSplitArray<ushort> Indices;
+        public SimpleSplitArray<AdjPoly> AdjPolys;
+        public SimpleSplitArray<Poly> Polys;
         public Sector SectorTree;
-        public ResourceSimpleArray<Portal> Portals;
+        public SimpleArray<Portal> Portals;
         public SimpleArray<ushort> p8data;
 
         /// <summary>
@@ -178,22 +178,22 @@ namespace RageLib.Resources.GTA5.PC.Navigations
             this.Unknown_16Ch = reader.ReadUInt32();
 
             // read reference data
-            this.Vertices = reader.ReadBlockAt<ResourceSplitArray<CompressedVertex>>(
+            this.Vertices = reader.ReadBlockAt<SimpleSplitArray<CompressedVertex>>(
                 this.VerticesPointer // offset
             );
-            this.Indices = reader.ReadBlockAt<ResourceSplitArray<ushort_r>>(
+            this.Indices = reader.ReadBlockAt<SimpleSplitArray<ushort>>(
                 this.IndicesPointer // offset
             );
-            this.AdjPolys = reader.ReadBlockAt<ResourceSplitArray<AdjPoly>>(
+            this.AdjPolys = reader.ReadBlockAt<SimpleSplitArray<AdjPoly>>(
                 this.AdjPolysPointer // offset
             );
-            this.Polys = reader.ReadBlockAt<ResourceSplitArray<Poly>>(
+            this.Polys = reader.ReadBlockAt<SimpleSplitArray<Poly>>(
                 this.PolysPointer // offset
             );
             this.SectorTree = reader.ReadBlockAt<Sector>(
                 this.SectorTreePointer // offset
             );
-            this.Portals = reader.ReadBlockAt<ResourceSimpleArray<Portal>>(
+            this.Portals = reader.ReadBlockAt<SimpleArray<Portal>>(
                 this.PortalsPointer, // offset
                 this.PortalsCount
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/Poly.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/Poly.cs
@@ -20,13 +20,13 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Navigations
 {
     // TNavMeshPoly
-    public class Poly : ResourceSystemBlock
+    public struct Poly : IResourceStruct<Poly>
     {
-        public override long BlockLength => 0x30;
-
         // structure data
         public uint Unknown_0h;
         public uint Unknown_4h;
@@ -41,44 +41,23 @@ namespace RageLib.Resources.GTA5.PC.Navigations
         public uint Unknown_28h;
         public uint Unknown_2Ch;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public Poly ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt32();
-            this.Unknown_4h = reader.ReadUInt32();
-            this.Unknown_8h = reader.ReadUInt32();
-            this.Unknown_Ch = reader.ReadUInt32();
-            this.Unknown_10h = reader.ReadUInt32();
-            this.Unknown_14h = reader.ReadUInt32();
-            this.Unknown_18h = reader.ReadUInt32();
-            this.Unknown_1Ch = reader.ReadUInt32();
-            this.Unknown_20h = reader.ReadUInt32();
-            this.Unknown_24h = reader.ReadUInt32();
-            this.Unknown_28h = reader.ReadUInt32();
-            this.Unknown_2Ch = reader.ReadUInt32();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_4h);
-            writer.Write(this.Unknown_8h);
-            writer.Write(this.Unknown_Ch);
-            writer.Write(this.Unknown_10h);
-            writer.Write(this.Unknown_14h);
-            writer.Write(this.Unknown_18h);
-            writer.Write(this.Unknown_1Ch);
-            writer.Write(this.Unknown_20h);
-            writer.Write(this.Unknown_24h);
-            writer.Write(this.Unknown_28h);
-            writer.Write(this.Unknown_2Ch);
+            return new Poly()
+            {
+                Unknown_0h = EndiannessExtensions.ReverseEndianness(Unknown_0h),
+                Unknown_4h = EndiannessExtensions.ReverseEndianness(Unknown_4h),
+                Unknown_8h = EndiannessExtensions.ReverseEndianness(Unknown_8h),
+                Unknown_Ch = EndiannessExtensions.ReverseEndianness(Unknown_Ch),
+                Unknown_10h = EndiannessExtensions.ReverseEndianness(Unknown_10h),
+                Unknown_14h = EndiannessExtensions.ReverseEndianness(Unknown_14h),
+                Unknown_18h = EndiannessExtensions.ReverseEndianness(Unknown_18h),
+                Unknown_1Ch = EndiannessExtensions.ReverseEndianness(Unknown_1Ch),
+                Unknown_20h = EndiannessExtensions.ReverseEndianness(Unknown_20h),
+                Unknown_24h = EndiannessExtensions.ReverseEndianness(Unknown_24h),
+                Unknown_28h = EndiannessExtensions.ReverseEndianness(Unknown_28h),
+                Unknown_2Ch = EndiannessExtensions.ReverseEndianness(Unknown_2Ch),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Navigations/Portal.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/Portal.cs
@@ -20,13 +20,13 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Navigations
 {
     // occurrences: 13969
-    public class Portal : ResourceSystemBlock
+    public struct Portal : IResourceStruct<Portal>
     {
-        public override long BlockLength => 28;
-
         // structure data
         public uint Unknown_0h;
         public uint Unknown_4h;
@@ -38,38 +38,20 @@ namespace RageLib.Resources.GTA5.PC.Navigations
         public ushort Unknown_16h;
         public uint Unknown_18h;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public Portal ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt32();
-            this.Unknown_4h = reader.ReadUInt32();
-            this.Unknown_8h = reader.ReadUInt32();
-            this.Unknown_Ch = reader.ReadUInt32();
-            this.Unknown_10h = reader.ReadUInt16();
-            this.Unknown_12h = reader.ReadUInt16();
-            this.Unknown_14h = reader.ReadUInt16();
-            this.Unknown_16h = reader.ReadUInt16();
-            this.Unknown_18h = reader.ReadUInt32();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_4h);
-            writer.Write(this.Unknown_8h);
-            writer.Write(this.Unknown_Ch);
-            writer.Write(this.Unknown_10h);
-            writer.Write(this.Unknown_12h);
-            writer.Write(this.Unknown_14h);
-            writer.Write(this.Unknown_16h);
-            writer.Write(this.Unknown_18h);
+            return new Portal()
+            {
+                Unknown_0h = EndiannessExtensions.ReverseEndianness(Unknown_0h),
+                Unknown_4h = EndiannessExtensions.ReverseEndianness(Unknown_4h),
+                Unknown_8h = EndiannessExtensions.ReverseEndianness(Unknown_8h),
+                Unknown_Ch = EndiannessExtensions.ReverseEndianness(Unknown_Ch),
+                Unknown_10h = EndiannessExtensions.ReverseEndianness(Unknown_10h),
+                Unknown_12h = EndiannessExtensions.ReverseEndianness(Unknown_12h),
+                Unknown_14h = EndiannessExtensions.ReverseEndianness(Unknown_14h),
+                Unknown_16h = EndiannessExtensions.ReverseEndianness(Unknown_16h),
+                Unknown_18h = EndiannessExtensions.ReverseEndianness(Unknown_18h),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Navigations/SectorData.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/SectorData.cs
@@ -40,7 +40,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
 
         // reference data
         public SimpleArray<ushort> p1data;
-        public ResourceSimpleArray<SectorDataUnk> p2data;
+        public SimpleArray<SectorDataUnk> p2data;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -61,7 +61,7 @@ namespace RageLib.Resources.GTA5.PC.Navigations
                 this.p1, // offset
                 this.c2
             );
-            this.p2data = reader.ReadBlockAt<ResourceSimpleArray<SectorDataUnk>>(
+            this.p2data = reader.ReadBlockAt<SimpleArray<SectorDataUnk>>(
                 this.p2, // offset
                 this.c3
             );

--- a/RageLib.GTA5/Resources/PC/Navigations/SectorDataUnk.cs
+++ b/RageLib.GTA5/Resources/PC/Navigations/SectorDataUnk.cs
@@ -20,40 +20,27 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Navigations
 {
-    public class SectorDataUnk : ResourceSystemBlock
+    public struct SectorDataUnk : IResourceStruct<SectorDataUnk>
     {
-        public override long BlockLength => 8;
-
         // structure data
         public ushort Unknown_0h;
         public ushort Unknown_2h;
         public ushort Unknown_4h;
         public ushort Unknown_6h;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public SectorDataUnk ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt16();
-            this.Unknown_2h = reader.ReadUInt16();
-            this.Unknown_4h = reader.ReadUInt16();
-            this.Unknown_6h = reader.ReadUInt16();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_2h);
-            writer.Write(this.Unknown_4h);
-            writer.Write(this.Unknown_6h);
+            return new SectorDataUnk()
+            {
+                Unknown_0h = EndiannessExtensions.ReverseEndianness(Unknown_0h),
+                Unknown_2h = EndiannessExtensions.ReverseEndianness(Unknown_2h),
+                Unknown_4h = EndiannessExtensions.ReverseEndianness(Unknown_4h),
+                Unknown_6h = EndiannessExtensions.ReverseEndianness(Unknown_6h),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Nodes/Node.cs
+++ b/RageLib.GTA5/Resources/PC/Nodes/Node.cs
@@ -20,12 +20,12 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Nodes
 {
-    public class Node : ResourceSystemBlock
+    public struct Node : IResourceStruct<Node>
     {
-        public override long BlockLength => 40;
-
         // structure data
         public uint Unknown_0h; // 0x00000000
         public uint Unknown_4h; // 0x00000000
@@ -39,42 +39,22 @@ namespace RageLib.Resources.GTA5.PC.Nodes
         public uint Unknown_20h;
         public uint Unknown_24h;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public Node ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt32();
-            this.Unknown_4h = reader.ReadUInt32();
-            this.Unknown_8h = reader.ReadUInt32();
-            this.Unknown_Ch = reader.ReadUInt32();
-            this.Unknown_10h = reader.ReadUInt16();
-            this.Unknown_12h = reader.ReadUInt16();
-            this.Unknown_14h = reader.ReadUInt32();
-            this.Unknown_18h = reader.ReadUInt32();
-            this.Unknown_1Ch = reader.ReadUInt32();
-            this.Unknown_20h = reader.ReadUInt32();
-            this.Unknown_24h = reader.ReadUInt32();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_4h);
-            writer.Write(this.Unknown_8h);
-            writer.Write(this.Unknown_Ch);
-            writer.Write(this.Unknown_10h);
-            writer.Write(this.Unknown_12h);
-            writer.Write(this.Unknown_14h);
-            writer.Write(this.Unknown_18h);
-            writer.Write(this.Unknown_1Ch);
-            writer.Write(this.Unknown_20h);
-            writer.Write(this.Unknown_24h);
+            return new Node()
+            {
+                Unknown_0h = EndiannessExtensions.ReverseEndianness(Unknown_0h),
+                Unknown_4h = EndiannessExtensions.ReverseEndianness(Unknown_4h),
+                Unknown_8h = EndiannessExtensions.ReverseEndianness(Unknown_8h),
+                Unknown_Ch = EndiannessExtensions.ReverseEndianness(Unknown_Ch),
+                Unknown_10h = EndiannessExtensions.ReverseEndianness(Unknown_10h),
+                Unknown_12h = EndiannessExtensions.ReverseEndianness(Unknown_12h),
+                Unknown_14h = EndiannessExtensions.ReverseEndianness(Unknown_14h),
+                Unknown_18h = EndiannessExtensions.ReverseEndianness(Unknown_18h),
+                Unknown_1Ch = EndiannessExtensions.ReverseEndianness(Unknown_1Ch),
+                Unknown_20h = EndiannessExtensions.ReverseEndianness(Unknown_20h),
+                Unknown_24h = EndiannessExtensions.ReverseEndianness(Unknown_24h),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Nodes/NodesFile.cs
+++ b/RageLib.GTA5/Resources/PC/Nodes/NodesFile.cs
@@ -52,11 +52,11 @@ namespace RageLib.Resources.GTA5.PC.Nodes
         public uint Unknown_6Ch; // 0x00000000
 
         // reference data
-        public ResourceSimpleArray<Node> Nodes;
-        public ResourceSimpleArray<Unknown_ND_002> Unknown_28h_Data;
-        public ResourceSimpleArray<Unknown_ND_003> Unknown_38h_Data;
+        public SimpleArray<Node> Nodes;
+        public SimpleArray<Unknown_ND_002> Unknown_28h_Data;
+        public SimpleArray<Unknown_ND_003> Unknown_38h_Data;
         public SimpleArray<byte> Unknown_40h_Data;
-        public ResourceSimpleArray<Unknown_ND_004> Unknown_50h_Data;
+        public SimpleArray<Unknown_ND_004> Unknown_50h_Data;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -88,15 +88,15 @@ namespace RageLib.Resources.GTA5.PC.Nodes
             this.Unknown_6Ch = reader.ReadUInt32();
 
             // read reference data
-            this.Nodes = reader.ReadBlockAt<ResourceSimpleArray<Node>>(
+            this.Nodes = reader.ReadBlockAt<SimpleArray<Node>>(
                 this.NodesPointer, // offset
                 this.NodesCount
             );
-            this.Unknown_28h_Data = reader.ReadBlockAt<ResourceSimpleArray<Unknown_ND_002>>(
+            this.Unknown_28h_Data = reader.ReadBlockAt<SimpleArray<Unknown_ND_002>>(
                 this.Unknown_28h_Pointer, // offset
                 this.DataPointer1Length
             );
-            this.Unknown_38h_Data = reader.ReadBlockAt<ResourceSimpleArray<Unknown_ND_003>>(
+            this.Unknown_38h_Data = reader.ReadBlockAt<SimpleArray<Unknown_ND_003>>(
                 this.Unknown_38h_Pointer, // offset
                 this.len4
             );
@@ -104,7 +104,7 @@ namespace RageLib.Resources.GTA5.PC.Nodes
                 this.Unknown_40h_Pointer, // offset
                 this.len5
             );
-            this.Unknown_50h_Data = reader.ReadBlockAt<ResourceSimpleArray<Unknown_ND_004>>(
+            this.Unknown_50h_Data = reader.ReadBlockAt<SimpleArray<Unknown_ND_004>>(
                 this.Unknown_50h_Pointer, // offset
                 this.cnt5b
             );

--- a/RageLib.GTA5/Resources/PC/Nodes/Unknown_ND_002.cs
+++ b/RageLib.GTA5/Resources/PC/Nodes/Unknown_ND_002.cs
@@ -20,34 +20,23 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Nodes
 {
-    public class Unknown_ND_002 : ResourceSystemBlock
+    public struct Unknown_ND_002 : IResourceStruct<Unknown_ND_002>
     {
-        public override long BlockLength => 8;
-
         // structure data
         public uint Unknown_0h;
         public uint Unknown_4h;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public Unknown_ND_002 ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt32();
-            this.Unknown_4h = reader.ReadUInt32();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_4h);
+            return new Unknown_ND_002()
+            {
+                Unknown_0h = EndiannessExtensions.ReverseEndianness(Unknown_0h),
+                Unknown_4h = EndiannessExtensions.ReverseEndianness(Unknown_4h),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Nodes/Unknown_ND_003.cs
+++ b/RageLib.GTA5/Resources/PC/Nodes/Unknown_ND_003.cs
@@ -20,37 +20,25 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Nodes
 {
-    public class Unknown_ND_003 : ResourceSystemBlock
+    public struct Unknown_ND_003 : IResourceStruct<Unknown_ND_003>
     {
-        public override long BlockLength => 12;
-
         // structure data
         public uint Unknown_0h;
         public uint Unknown_4h;
         public uint Unknown_8h;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public Unknown_ND_003 ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt32();
-            this.Unknown_4h = reader.ReadUInt32();
-            this.Unknown_8h = reader.ReadUInt32();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_4h);
-            writer.Write(this.Unknown_8h);
+            return new Unknown_ND_003()
+            {
+                Unknown_0h = EndiannessExtensions.ReverseEndianness(Unknown_0h),
+                Unknown_4h = EndiannessExtensions.ReverseEndianness(Unknown_4h),
+                Unknown_8h = EndiannessExtensions.ReverseEndianness(Unknown_8h),
+            };
         }
     }
 }

--- a/RageLib.GTA5/Resources/PC/Nodes/Unknown_ND_004.cs
+++ b/RageLib.GTA5/Resources/PC/Nodes/Unknown_ND_004.cs
@@ -20,37 +20,25 @@
     THE SOFTWARE.
 */
 
+using RageLib.Data;
+
 namespace RageLib.Resources.GTA5.PC.Nodes
 {
-    public class Unknown_ND_004 : ResourceSystemBlock
+    public struct Unknown_ND_004 : IResourceStruct<Unknown_ND_004>
     {
-        public override long BlockLength => 8;
-
         // structure data
         public ushort Unknown_0h;
         public ushort Unknown_2h;
         public uint Unknown_4h;
 
-        /// <summary>
-        /// Reads the data-block from a stream.
-        /// </summary>
-        public override void Read(ResourceDataReader reader, params object[] parameters)
+        public Unknown_ND_004 ReverseEndianness()
         {
-            // read structure data
-            this.Unknown_0h = reader.ReadUInt16();
-            this.Unknown_2h = reader.ReadUInt16();
-            this.Unknown_4h = reader.ReadUInt32();
-        }
-
-        /// <summary>
-        /// Writes the data-block to a stream.
-        /// </summary>
-        public override void Write(ResourceDataWriter writer, params object[] parameters)
-        {
-            // write structure data
-            writer.Write(this.Unknown_0h);
-            writer.Write(this.Unknown_2h);
-            writer.Write(this.Unknown_4h);
+            return new Unknown_ND_004()
+            {
+                Unknown_0h = EndiannessExtensions.ReverseEndianness(Unknown_0h),
+                Unknown_2h = EndiannessExtensions.ReverseEndianness(Unknown_2h),
+                Unknown_4h = EndiannessExtensions.ReverseEndianness(Unknown_4h),
+            };
         }
     }
 }

--- a/RageLib/Resources/Common/Collections/SimpleList64_32.cs
+++ b/RageLib/Resources/Common/Collections/SimpleList64_32.cs
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 namespace RageLib.Resources.Common
 {
     // TODO: Find a better name to these classes
-    public class ResourceSimpleList32_64<T> : ResourceSystemBlock where T : IResourceSystemBlock, new()
+    public class SimpleList64_32<T> : ResourceSystemBlock where T : unmanaged
     {
         public override long BlockLength
         {
@@ -39,7 +39,7 @@ namespace RageLib.Resources.Common
         public uint EntriesCapacity;
 
         // reference data
-        public ResourceSimpleArray<T> Entries;
+        public SimpleArray<T> Entries;
 
         /// <summary>
         /// Reads the data-block from a stream.
@@ -52,7 +52,7 @@ namespace RageLib.Resources.Common
             this.EntriesCapacity = reader.ReadUInt32();
 
             // read reference data
-            this.Entries = reader.ReadBlockAt<ResourceSimpleArray<T>>(
+            this.Entries = reader.ReadBlockAt<SimpleArray<T>>(
                 this.EntriesPointer, // offset
                 this.EntriesCapacity
             );

--- a/RageLib/Resources/Common/Collections/SimpleSplitArray.cs
+++ b/RageLib/Resources/Common/Collections/SimpleSplitArray.cs
@@ -1,0 +1,147 @@
+﻿using System.Collections.Generic;
+
+namespace RageLib.Resources.Common
+{
+    // aiSplitArray<T, C>
+    // C is used as max capacity of each SplitArrayPart<T>
+    // C = 16.384 / size of (T)
+    // Examples: 
+    //          aiSplitArray<CNavMeshCompressedVertex,2730>
+    //          aiSplitArray<TAdjPoly,2048>
+    //          aiSplitArray<ushort,8192>
+    //          aiSplitArray<TNavMeshPoly,341>
+    public class SimpleSplitArray<T> : ResourceSystemBlock where T : unmanaged
+    {
+        public override long BlockLength => 0x30;
+
+        // structure data
+        public ulong VFT;
+        public uint EntriesCount;
+        public uint Unknown_Ch; // 0x00000000
+        public ulong PartsPointer;
+        public ulong OffsetsPointer;
+        public uint PartsCount;
+        public uint Unknown_24h; // 0x00000000
+        public uint Unknown_28h; // 0x00000000
+        public uint Unknown_2Ch; // 0x00000000
+
+        // reference data
+        public ResourceSimpleArray<SimpleSplitArrayPart<T>> Parts;
+        public SimpleArray<uint> Offsets;
+
+        /// <summary>
+        /// Reads the data-block from a stream.
+        /// </summary>
+        public override void Read(ResourceDataReader reader, params object[] parameters)
+        {
+            // read structure data
+            this.VFT = reader.ReadUInt64();
+            this.EntriesCount = reader.ReadUInt32();
+            this.Unknown_Ch = reader.ReadUInt32();
+            this.PartsPointer = reader.ReadUInt64();
+            this.OffsetsPointer = reader.ReadUInt64();
+            this.PartsCount = reader.ReadUInt32();
+            this.Unknown_24h = reader.ReadUInt32();
+            this.Unknown_28h = reader.ReadUInt32();
+            this.Unknown_2Ch = reader.ReadUInt32();
+
+            // read reference data
+            this.Parts = reader.ReadBlockAt<ResourceSimpleArray<SimpleSplitArrayPart<T>>>(
+                this.PartsPointer, // offset
+                this.PartsCount
+            );
+            this.Offsets = reader.ReadBlockAt<SimpleArray<uint>>(
+                this.OffsetsPointer, // offset
+                this.PartsCount
+            );
+        }
+
+        /// <summary>
+        /// Writes the data-block to a stream.
+        /// </summary>
+        public override void Write(ResourceDataWriter writer, params object[] parameters)
+        {
+            // update structure data
+            this.PartsPointer = (ulong)(this.Parts != null ? this.Parts.BlockPosition : 0);
+            this.OffsetsPointer = (ulong)(this.Offsets != null ? this.Offsets.BlockPosition : 0);
+            this.PartsCount = (uint)(this.Parts != null ? this.Parts.Count : 0);
+
+            // write structure data
+            writer.Write(this.VFT);
+            writer.Write(this.EntriesCount);
+            writer.Write(this.Unknown_Ch);
+            writer.Write(this.PartsPointer);
+            writer.Write(this.OffsetsPointer);
+            writer.Write(this.PartsCount);
+            writer.Write(this.Unknown_24h);
+            writer.Write(this.Unknown_28h);
+            writer.Write(this.Unknown_2Ch);
+        }
+
+        /// <summary>
+        /// Returns a list of data blocks which are referenced by this block.
+        /// </summary>
+        public override IResourceBlock[] GetReferences()
+        {
+            var list = new List<IResourceBlock>();
+            if (Parts != null) list.Add(Parts);
+            if (Offsets != null) list.Add(Offsets);
+            return list.ToArray();
+        }
+    }
+
+    public class SimpleSplitArrayPart<T> : ResourceSystemBlock where T : unmanaged
+    {
+        public override long BlockLength => 0x10;
+
+        // structure data
+        public ulong Pointer;
+        public uint Count;
+        public uint Unknown_Ch; // 0x00000000
+
+        // reference data
+        public SimpleArray<T> Entries;
+
+        /// <summary>
+        /// Reads the data-block from a stream.
+        /// </summary>
+        public override void Read(ResourceDataReader reader, params object[] parameters)
+        {
+            // read structure data
+            this.Pointer = reader.ReadUInt64();
+            this.Count = reader.ReadUInt32();
+            this.Unknown_Ch = reader.ReadUInt32();
+
+            // read reference data
+            this.Entries = reader.ReadBlockAt<SimpleArray<T>>(
+                this.Pointer, // offset
+                this.Count
+            );
+        }
+
+        /// <summary>
+        /// Writes the data-block to a stream.
+        /// </summary>
+        public override void Write(ResourceDataWriter writer, params object[] parameters)
+        {
+            // update structure data
+            this.Pointer = (ulong)(this.Entries != null ? this.Entries.BlockPosition : 0);
+            this.Count = (uint)(this.Entries != null ? this.Entries.Count : 0);
+
+            // write structure data
+            writer.Write(this.Pointer);
+            writer.Write(this.Count);
+            writer.Write(this.Unknown_Ch);
+        }
+
+        /// <summary>
+        /// Returns a list of data blocks which are referenced by this block.
+        /// </summary>
+        public override IResourceBlock[] GetReferences()
+        {
+            var list = new List<IResourceBlock>();
+            if (Entries != null) list.Add(Entries);
+            return list.ToArray();
+        }
+    }
+}

--- a/RageLib/Resources/IResourceBlock.cs
+++ b/RageLib/Resources/IResourceBlock.cs
@@ -81,4 +81,17 @@ namespace RageLib.Resources
     /// </summary>
     public interface IResourceGraphicsBlock : IResourceBlock
     { }
+
+    /// <summary>
+    /// Represents a struct of unmanaged type which is not a primitive type.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IResourceStruct<T> where T : unmanaged
+    {
+        /// <summary>
+        /// Returns a copy of the <see cref="T"/> instance with the endianness of all its fields reversed.
+        /// </summary>
+        /// <returns></returns>
+        T ReverseEndianness();
+    }
 }


### PR DESCRIPTION
Closes https://github.com/carmineos/gta-toolkit/issues/17

Some small structs which only happen to be packed into arrays can be replaced with structs.
Such structs have to implement the new `IResourceStruct<T>` interface which for now only ensures contains a method allowing to return a copy of the instance in which all the fields have their endianness reversed.
This covers blocks from Bounds, Nodes, Navigation.

Both loading and saving of such resources get great benefits from this change in both speed and allocated managed memory. 

Before:
```
|      Method |             filename |  save |           Mean |        Error |       StdDev |      Gen 0 |      Gen 1 |     Gen 2 |    Allocated |
|------------ |--------------------- |------ |---------------:|-------------:|-------------:|-----------:|-----------:|----------:|-------------:|
| LoadSaveYbn |  cs6_08_mine_int.ybn | False |   290,886.0 us |  5,784.90 us |  8,479.43 us | 11000.0000 |  5000.0000 | 2000.0000 |  80738.54 KB |
| LoadSaveYbn |  cs6_08_mine_int.ybn |  True |   559,022.4 us |  8,641.19 us |  7,215.78 us | 20000.0000 | 10000.0000 | 4000.0000 | 114639.11 KB |
| LoadSaveYnv | navme(...)].ynv [21] | False |     7,209.3 us |     94.76 us |     88.64 us |   500.0000 |   250.0000 |  250.0000 |   3518.87 KB |
| LoadSaveYnv | navme(...)].ynv [21] |  True |    15,771.8 us |    298.52 us |    319.41 us |   828.1250 |   484.3750 |  296.8750 |   4990.52 KB |
| LoadSaveYnd |         nodes300.ynd | False |       380.3 us |      5.72 us |      5.35 us |    13.1836 |          - |         - |     54.98 KB |
| LoadSaveYnd |         nodes300.ynd |  True |       962.2 us |     19.16 us |     21.29 us |    21.4844 |     1.9531 |         - |     88.56 KB |
```

After:
```
|      Method |             filename |  save |           Mean |        Error |       StdDev |      Gen 0 |      Gen 1 |     Gen 2 |    Allocated |
|------------ |--------------------- |------ |---------------:|-------------:|-------------:|-----------:|-----------:|----------:|-------------:|
| LoadSaveYbn |  cs6_08_mine_int.ybn | False |    27,164.6 μs |     91.88 μs |     71.74 μs |  1375.0000 |  1000.0000 |  656.2500 |    8644.7 KB |
| LoadSaveYbn |  cs6_08_mine_int.ybn |  True |   174,738.4 μs |  1,121.60 μs |    994.27 μs |  1666.6667 |  1333.3333 | 1000.0000 |   13074.7 KB |
| LoadSaveYnv | navme(...)].ynv [21] | False |     1,087.3 μs |     21.60 μs |     26.53 μs |    44.9219 |    44.9219 |   44.9219 |    306.31 KB |
| LoadSaveYnv | navme(...)].ynv [21] |  True |     5,819.6 μs |     77.73 μs |     72.71 μs |    85.9375 |    85.9375 |   85.9375 |    485.53 KB |
| LoadSaveYnd |         nodes300.ynd | False |       289.6 μs |      5.38 μs |      5.28 μs |     4.3945 |          - |         - |     19.63 KB |
| LoadSaveYnd |         nodes300.ynd |  True |       831.9 μs |      7.84 μs |      6.95 μs |     8.7891 |          - |         - |     38.03 KB |
```